### PR TITLE
로그인 api 연동

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -36,5 +36,6 @@ module.exports = {
     'no-console': 'off',
     'react/button-has-type': 'off',
     'no-unused-vars': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 # ESLint
 .eslintcache
+
+# .env
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@mui/icons-material": "^5.16.0",
         "@mui/material": "^5.16.0",
         "@mui/x-date-pickers": "^7.13.0",
+        "@tanstack/react-query": "^5.52.1",
+        "axios": "^1.7.5",
         "dayjs": "^1.11.12",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1765,6 +1767,32 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.52.0.tgz",
+      "integrity": "sha512-U1DOEgltjUwalN6uWYTewSnA14b+tE7lSylOiASKCAO61ENJeCq9VVD/TXHA6O5u9+6v5+UgGYBSccTKDoyMqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.52.1.tgz",
+      "integrity": "sha512-soyn4dNIUZ8US8NaPVXv06gkZFHaZnPfKWPDjRJjFRW3Y7WZ0jx72eT6zhw3VQlkMPysmXye8l35ewPHspKgbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.52.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2149,6 +2177,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2173,6 +2207,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2355,6 +2400,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2571,6 +2628,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/doctrine": {
@@ -3486,6 +3552,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3494,6 +3580,20 @@
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -4463,6 +4563,27 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4894,6 +5015,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "dayjs": "^1.11.12",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.24.1"
+        "react-router-dom": "^6.24.1",
+        "zustand": "^4.5.5"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -5854,6 +5855,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
@@ -6053,6 +6063,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
+      "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^5.16.0",
         "@mui/x-date-pickers": "^7.13.0",
         "@tanstack/react-query": "^5.52.1",
+        "@tanstack/react-query-devtools": "^5.54.1",
         "axios": "^1.7.5",
         "dayjs": "^1.11.12",
         "react": "^18.3.1",
@@ -1768,9 +1769,19 @@
       ]
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.52.0.tgz",
-      "integrity": "sha512-U1DOEgltjUwalN6uWYTewSnA14b+tE7lSylOiASKCAO61ENJeCq9VVD/TXHA6O5u9+6v5+UgGYBSccTKDoyMqw==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.54.1.tgz",
+      "integrity": "sha512-hKS+WRpT5zBFip21pB6Jx1C0hranWQrbv5EJ7qPoiV5MYI3C8rTCqWC9DdBseiPT1JgQWh8Y55YthuYZNiw3Xw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.54.0.tgz",
+      "integrity": "sha512-B8Sa6mh7/4m2fyk2/YnUXeOZ1/us7G/C/i1It8YcCbieXc8vf1AdSYjR+mZIoJeKOKLqA741hZqfj8d4F1NCVg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1778,18 +1789,35 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.52.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.52.1.tgz",
-      "integrity": "sha512-soyn4dNIUZ8US8NaPVXv06gkZFHaZnPfKWPDjRJjFRW3Y7WZ0jx72eT6zhw3VQlkMPysmXye8l35ewPHspKgbQ==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.54.1.tgz",
+      "integrity": "sha512-SuMi4JBYv49UtmiRyqjxY7XAnE1qwLht9nlkC8sioxFXz5Uzj30lepiKf2mYXuXfC7fHYjTrAPkNx+427pRHXA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.52.0"
+        "@tanstack/query-core": "5.54.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.54.1.tgz",
+      "integrity": "sha512-6kJoLujP1f+8dSoOjK15uJl79XhTAdyPIKIcMJ33s5zIva6d7AUuTWoj7opcfkUvU/Jy0xXivHPsrhFHhi0SxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.54.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.54.1",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "dayjs": "^1.11.12",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.24.1"
+    "react-router-dom": "^6.24.1",
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mui/material": "^5.16.0",
     "@mui/x-date-pickers": "^7.13.0",
     "@tanstack/react-query": "^5.52.1",
+    "@tanstack/react-query-devtools": "^5.54.1",
     "axios": "^1.7.5",
     "dayjs": "^1.11.12",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@mui/icons-material": "^5.16.0",
     "@mui/material": "^5.16.0",
     "@mui/x-date-pickers": "^7.13.0",
+    "@tanstack/react-query": "^5.52.1",
+    "axios": "^1.7.5",
     "dayjs": "^1.11.12",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import { Routes, Route, BrowserRouter } from 'react-router-dom';
+import React from 'react';
+import { Routes, Route, BrowserRouter, Outlet } from 'react-router-dom';
 import { Container, Box, Typography, Button } from '@mui/material';
-import { Teacher } from './components';
+import { Director, Teacher } from './components';
 import { Login, SignUp, Register, NotFound, DirectorHome, TeacherHome, RequestList, ManageTeachers, ManageStudents } from './pages';
 import { PATH } from './route/path';
 import { useUserAuthStore } from './store';
@@ -16,16 +16,24 @@ function App() {
           <Route path={PATH.root} element={isLoggedIn ? <Register name="홍길동" position="teacher" /> : <FirstPage />} />
           <Route path={PATH.SIGNUP} element={<SignUp />} />
           <Route path={PATH.LOGIN} element={<Login />} />
+
           <Route path={PATH.TEACHER.ROOT} element={<Teacher />}>
             <Route path="" element={<TeacherHome />} />
             <Route path="*" element={<NotFound path={PATH.TEACHER.ROOT} />} />
           </Route>
+
+          <Route path={PATH.DIRECTOR.ROOT} element={<Director />}>
+            <Route path="" element={<DirectorHome />} />
+            <Route path={PATH.DIRECTOR.MANAGE_MEMBERS.ROOT} element={<Outlet />}>
+              <Route path={PATH.DIRECTOR.MANAGE_MEMBERS.REQUESTLIST} element={<RequestList />} />
+              <Route path={PATH.DIRECTOR.MANAGE_MEMBERS.TEACHERS} element={<ManageTeachers />} />
+              <Route path={PATH.DIRECTOR.MANAGE_MEMBERS.STUDENTS} element={<ManageStudents />} />
+            </Route>
+            <Route path="*" element={<NotFound path={PATH.DIRECTOR.ROOT} />} />
+          </Route>
+
           {/* notFound : 일치하는 라우트 없는 경우 처리 */}
           <Route path="*" element={<NotFound />} />
-          <Route path="/director" element={<DirectorHome />} />
-          <Route path="/director/manage-members/request-list" element={<RequestList />} />
-          <Route path="/director/manage-members/teachers" element={<ManageTeachers />} />
-          <Route path="/director/manage-members/students" element={<ManageStudents />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Routes, Route, BrowserRouter } from 'react-router-dom';
 import { Container, Box, Typography, Button } from '@mui/material';
 import { Login, SignUp, Register, NotFound, DirectorHome, TeacherHome, RequestList, ManageTeachers, ManageStudents } from './pages';
+import { PATH } from './route/path';
 
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -10,9 +11,9 @@ function App() {
     <div className="App">
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={isLoggedIn ? <Register name="홍길동" position="teacher" /> : <FirstPage />} />
-          <Route path="/signup" element={<SignUp />} />
-          <Route path="/login" element={<Login setIsLoggedIn={setIsLoggedIn} />} />
+          <Route path={PATH.root} element={isLoggedIn ? <Register name="홍길동" position="teacher" /> : <FirstPage />} />
+          <Route path={PATH.SIGNUP} element={<SignUp />} />
+          <Route path={PATH.LOGIN} element={<Login setIsLoggedIn={setIsLoggedIn} />} />
           <Route path="/teacher" element={<TeacherHome />} />
           {/* notFound : 일치하는 라우트 없는 경우 처리 */}
           <Route path="*" element={<NotFound />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Routes, Route, BrowserRouter } from 'react-router-dom';
 import { Container, Box, Typography, Button } from '@mui/material';
 import { Login, SignUp, Register, NotFound, DirectorHome, TeacherHome, RequestList, ManageTeachers, ManageStudents } from './pages';
@@ -6,6 +6,13 @@ import { PATH } from './route/path';
 
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const accessToken = localStorage.getItem('accessToken');
+
+  useEffect(() => {
+    if (accessToken) {
+      setIsLoggedIn(true);
+    }
+  }, [accessToken]);
 
   return (
     <div className="App">
@@ -13,7 +20,7 @@ function App() {
         <Routes>
           <Route path={PATH.root} element={isLoggedIn ? <Register name="홍길동" position="teacher" /> : <FirstPage />} />
           <Route path={PATH.SIGNUP} element={<SignUp />} />
-          <Route path={PATH.LOGIN} element={<Login setIsLoggedIn={setIsLoggedIn} />} />
+          <Route path={PATH.LOGIN} element={<Login />} />
           <Route path="/teacher" element={<TeacherHome />} />
           {/* notFound : 일치하는 라우트 없는 경우 처리 */}
           <Route path="*" element={<NotFound />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,16 +3,10 @@ import { Routes, Route, BrowserRouter } from 'react-router-dom';
 import { Container, Box, Typography, Button } from '@mui/material';
 import { Login, SignUp, Register, NotFound, DirectorHome, TeacherHome, RequestList, ManageTeachers, ManageStudents } from './pages';
 import { PATH } from './route/path';
+import { useUserAuthStore } from './store';
 
 function App() {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const accessToken = localStorage.getItem('accessToken');
-
-  useEffect(() => {
-    if (accessToken) {
-      setIsLoggedIn(true);
-    }
-  }, [accessToken]);
+  const { isLoggedIn } = useUserAuthStore();
 
   return (
     <div className="App">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Routes, Route, BrowserRouter } from 'react-router-dom';
 import { Container, Box, Typography, Button } from '@mui/material';
+import { Teacher } from './components';
 import { Login, SignUp, Register, NotFound, DirectorHome, TeacherHome, RequestList, ManageTeachers, ManageStudents } from './pages';
 import { PATH } from './route/path';
 import { useUserAuthStore } from './store';
@@ -15,7 +16,10 @@ function App() {
           <Route path={PATH.root} element={isLoggedIn ? <Register name="홍길동" position="teacher" /> : <FirstPage />} />
           <Route path={PATH.SIGNUP} element={<SignUp />} />
           <Route path={PATH.LOGIN} element={<Login />} />
-          <Route path="/teacher" element={<TeacherHome />} />
+          <Route path={PATH.TEACHER.ROOT} element={<Teacher />}>
+            <Route path="" element={<TeacherHome />} />
+            <Route path="*" element={<NotFound path={PATH.TEACHER.ROOT} />} />
+          </Route>
           {/* notFound : 일치하는 라우트 없는 경우 처리 */}
           <Route path="*" element={<NotFound />} />
           <Route path="/director" element={<DirectorHome />} />

--- a/src/api/api_utils.js
+++ b/src/api/api_utils.js
@@ -1,5 +1,5 @@
 // routes
-import { handleAlert } from 'react-handle-alert';
+// import { handleAlert } from 'react-handle-alert';
 import { axiosInstance } from './axios';
 import { PATH_API } from './path';
 
@@ -56,7 +56,8 @@ const tokenRefresh = async () => {
 
       return newAccessToken;
     } catch {
-      handleAlert('로그인이 만료되었습니다.');
+      // handleAlert('로그인이 만료되었습니다.');
+      alert('로그인이 만료되었습니다.');
 
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
@@ -91,7 +92,8 @@ export const tokenExpired = (exp) => {
 
 export const setSession = (token) => {
   const { accessToken, refreshToken } = token;
-  if (accessToken && refreshToken) {
+  // if (accessToken && refreshToken) {
+  if (accessToken) {
     localStorage.setItem('accessToken', accessToken);
     localStorage.setItem('refreshToken', refreshToken);
 

--- a/src/api/api_utils.js
+++ b/src/api/api_utils.js
@@ -1,0 +1,129 @@
+// routes
+import { handleAlert } from 'react-handle-alert';
+import { axiosInstance } from './axios';
+import { PATH_API } from './path';
+
+// utils
+
+// ----------------------------------------------------------------------
+
+function jwtDecode(token) {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const jsonPayload = decodeURIComponent(
+    window
+      .atob(base64)
+      .split('')
+      .map((c) => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+      .join('')
+  );
+
+  return JSON.parse(jsonPayload);
+}
+
+// ----------------------------------------------------------------------
+
+export const isValidToken = (accessToken) => {
+  if (!accessToken) {
+    return false;
+  }
+
+  const decoded = jwtDecode(accessToken);
+
+  const currentTime = Date.now() / 1000;
+
+  return decoded.exp > currentTime;
+};
+
+// ----------------------------------------------------------------------
+
+const tokenRefresh = async () => {
+  const refreshToken = localStorage.getItem('refreshToken');
+  if (refreshToken) {
+    try {
+      const response = await axiosInstance.post(PATH_API.TOKEN_REISSUE, {
+        refreshToken,
+      });
+
+      const newAccessToken = response.data.accessToken;
+      localStorage.setItem('accessToken', newAccessToken);
+
+      axiosInstance.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
+
+      const { exp } = jwtDecode(newAccessToken);
+      // eslint-disable-next-line no-use-before-define
+      tokenExpired(exp);
+
+      return newAccessToken;
+    } catch {
+      handleAlert('로그인이 만료되었습니다.');
+
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+
+      window.location.reload();
+    }
+  }
+};
+
+export const tokenExpired = (exp) => {
+  let expiredTimer;
+
+  const currentTime = Date.now();
+
+  // 만료 되기 5분 전에 토큰 갱신
+  // Test token expires after 10s
+  const timeLeft = exp * 1000 - currentTime;
+
+  clearTimeout(expiredTimer);
+
+  // 1일보다 많이 남으면 실행하지 않음
+  if (timeLeft >= 86400000) {
+    return;
+  }
+
+  expiredTimer = setTimeout(() => {
+    tokenRefresh();
+  }, timeLeft);
+};
+
+// ----------------------------------------------------------------------
+
+export const setSession = (token) => {
+  const { accessToken, refreshToken } = token;
+  if (accessToken && refreshToken) {
+    localStorage.setItem('accessToken', accessToken);
+    localStorage.setItem('refreshToken', refreshToken);
+
+    axiosInstance.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+
+    const { exp } = jwtDecode(accessToken);
+    tokenExpired(exp);
+  } else {
+    localStorage.removeItem('accessToken');
+
+    delete axiosInstance.defaults.headers.common.Authorization;
+  }
+};
+
+// ----------------------------------------------------------------------
+
+export const removeSession = () => {
+  localStorage.removeItem('accessToken');
+  localStorage.removeItem('refreshToken');
+
+  delete axiosInstance.defaults.headers.common.Authorization;
+};
+
+// ----------------------------------------------------------------------
+
+export const getUserId = () => {
+  const accessToken = localStorage.getItem('accessToken');
+  if (!accessToken) {
+    return '';
+  }
+
+  const { id } = jwtDecode(accessToken);
+
+  return id;
+};

--- a/src/api/api_utils.js
+++ b/src/api/api_utils.js
@@ -98,15 +98,12 @@ export const tokenExpired = (exp) => {
 
 // ----------------------------------------------------------------------
 /**
- * store accessToken to localStorage
- * @param {any} token
+ * store accessToken to localStorage & axios header
+ * @param {any} accessToken
  */
-export const setSession = (token) => {
-  const { accessToken, refreshToken } = token;
-  // if (accessToken && refreshToken) {
+export const setSession = (accessToken) => {
   if (accessToken) {
     localStorage.setItem('accessToken', accessToken);
-    localStorage.setItem('refreshToken', refreshToken);
 
     axiosInstance.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
 
@@ -124,7 +121,6 @@ export const setSession = (token) => {
 
 export const removeSession = () => {
   localStorage.removeItem('accessToken');
-  localStorage.removeItem('refreshToken');
 
   delete axiosInstance.defaults.headers.common.Authorization;
 };

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -8,7 +8,7 @@ const TIMEOUT_TIME = 10_000;
 export const axiosInstance = axios.create({
   baseURL: PATH_API.API_DOMAIN,
   headers: {
-    'Content-Type': 'application/vnd.api+json',
+    'Content-Type': 'application/json',
   },
   // withCredentials:true, // 쿠키 cors 통신 설정
 });

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -10,7 +10,7 @@ export const axiosInstance = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  // withCredentials:true, // 쿠키 cors 통신 설정
+  withCredentials: true, // 쿠키 cors 통신 설정
 });
 
 // 취소 토큰을 생성하는 함수
@@ -28,12 +28,14 @@ let firstRequestCancelToken = null;
 axiosInstance.interceptors.request.use(
   async (config) => {
     const token = localStorage.getItem('accessToken');
+    /* eslint-disable no-param-reassign */
     config.headers.Authorization = `Bearer ${token}`;
 
     firstRequestCancelToken = cancelTokenSource();
     config.cancelToken = firstRequestCancelToken.token;
     config.timeout = TIMEOUT_TIME;
     return config;
+    /* eslint-enable no-param-reassign */
   },
   (error) =>
     // 요청 전 에러 처리
@@ -46,8 +48,10 @@ axiosInstance.interceptors.response.use(
   async (error) => {
     // invalid token
     const originalRequest = error.config;
+    /* eslint-disable no-underscore-dangle */
     if (error.response.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
+
       //   const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY!);
 
       // if (refreshToken) {
@@ -73,6 +77,8 @@ axiosInstance.interceptors.response.use(
       // }
       // }
     }
+    /* eslint-enable no-underscore-dangle */
+
     // timeout
     if (axios.isCancel(error)) {
       // 취소된 요청은 에러로 처리하지 않음

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,0 +1,87 @@
+import axios from 'axios';
+
+import { PATH_API } from './path';
+import { PATH } from '../route/path';
+
+const TIMEOUT_TIME = 10_000;
+
+export const axiosInstance = axios.create({
+  baseURL: PATH_API.API_DOMAIN,
+  headers: {
+    'Content-Type': 'application/vnd.api+json',
+  },
+  // withCredentials:true, // 쿠키 cors 통신 설정
+});
+
+// 취소 토큰을 생성하는 함수
+const cancelTokenSource = () => {
+  const cancelToken = axios.CancelToken.source();
+  return {
+    token: cancelToken.token,
+    cancel: cancelToken.cancel,
+  };
+};
+
+let firstRequestCancelToken = null;
+// Request interceptor for API calls
+
+axiosInstance.interceptors.request.use(
+  async (config) => {
+    const token = localStorage.getItem('accessToken');
+    config.headers.Authorization = `Bearer ${token}`;
+
+    firstRequestCancelToken = cancelTokenSource();
+    config.cancelToken = firstRequestCancelToken.token;
+    config.timeout = TIMEOUT_TIME;
+    return config;
+  },
+  (error) =>
+    // 요청 전 에러 처리
+    // add error handling before sending the request
+    Promise.reject((error.response && error.response.data) || 'Something went wrong')
+);
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    // invalid token
+    const originalRequest = error.config;
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      //   const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY!);
+
+      // if (refreshToken) {
+      //   try {
+      //     const response = await axiosInstance.post(PATH_API.TOKEN_REISSUE, {
+      //       refreshToken,
+      //     });
+      //     const newAccessToken = response.data.accessToken;
+      //     localStorage.setItem(ACCESS_TOKEN_KEY!, newAccessToken);
+
+      //     // axiosInstance.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+      //     originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+      //     return await axiosInstance(originalRequest);
+      //   } catch {
+      // 리프레시 토큰도 만료된 경우 로그아웃 처리
+      alert('system.axios-401-error');
+      localStorage.removeItem('accessToken');
+      delete originalRequest.Authorization;
+
+      // window.location.reload();
+      window.location.href = PATH.root;
+      // Promise.resolve('Error! failed token refresh');
+      // }
+      // }
+    }
+    // timeout
+    if (axios.isCancel(error)) {
+      // 취소된 요청은 에러로 처리하지 않음
+      await Promise.resolve();
+    }
+
+    // 그 외의 에러는 그대로 반환
+    return Promise.reject((error.response && error.response.data) || 'Something went wrong');
+  }
+);
+
+export default axiosInstance;

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -2,10 +2,9 @@ import { SECRET } from '../config/secret';
 
 export const PATH_API = {
   API_DOMAIN: SECRET.server_ip,
-  // auth
-  SIGN_IN: '/auth/sign-in',
-  SIGN_UP: '/auth/sign-up',
-  SIGN_OUT: '/auth/sign-out',
+  // user
+  SIGN_IN: '/user/login',
+  SIGN_UP: '/user/signup',
 };
 
 export default PATH_API;

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -1,0 +1,11 @@
+import { SECRET } from '../config/secret';
+
+export const PATH_API = {
+  API_DOMAIN: SECRET.server_ip,
+  // auth
+  SIGN_IN: '/auth/sign-in',
+  SIGN_UP: '/auth/sign-up',
+  SIGN_OUT: '/auth/sign-out',
+};
+
+export default PATH_API;

--- a/src/api/queries/user/useLogin.js
+++ b/src/api/queries/user/useLogin.js
@@ -6,9 +6,11 @@ import { axiosInstance } from '../../axios';
 import { QUERY_KEY } from '../../queryKeys';
 import { setSession } from '../../api_utils';
 import { PATH } from '../../../route/path';
+import { useUserAuthStore } from '../../../store';
 
 export const useLogin = (options) => {
   const navigate = useNavigate();
+  const { login } = useUserAuthStore();
 
   return useMutation({
     mutationKey: [QUERY_KEY.SIGN_IN],
@@ -17,7 +19,8 @@ export const useLogin = (options) => {
       return response.data;
     },
     onSuccess: (data) => {
-      setSession(data);
+      setSession(data.accessToken);
+      login({ ...data.user, userStatus: data.userStatus });
       navigate(PATH.root);
     },
     onError: (error) => {

--- a/src/api/queries/user/useLogin.js
+++ b/src/api/queries/user/useLogin.js
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query';
+// import { useSnackbar } from 'notistack';
+import { useNavigate } from 'react-router-dom';
+import { PATH_API } from '../../path';
+import { axiosInstance } from '../../axios';
+import { QUERY_KEY } from '../../queryKeys';
+import { setSession } from '../../api_utils';
+import { PATH } from '../../../route/path';
+
+export const useLogin = (options) => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationKey: [QUERY_KEY.SIGN_IN],
+    mutationFn: async (payload) => {
+      const response = await axiosInstance.post(PATH_API.SIGN_IN, payload);
+      return response.data;
+    },
+    onSuccess: (data) => {
+      setSession(data);
+      navigate(PATH.root);
+    },
+    onError: (error) => {
+      console.log('error occurred at useLogin:', error);
+    },
+    ...options,
+  });
+};
+
+export default useLogin;

--- a/src/api/queryClient.js
+++ b/src/api/queryClient.js
@@ -1,0 +1,14 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false, // 브라우저에 포커스가 들어온 경우
+      refetchOnMount: true, // 새로운 컴포넌트 마운트가 발생한 경우
+      refetchOnReconnect: true, // 네트워크 재연결이 발생한 경우
+      staleTime: 0, // 데이터가 fresh -> stale 되는 시간
+      gcTime: 0, // 캐시된 데이터가 얼마나 오랫동안 메모리에 유지될 것인지
+      retry: 0,
+    },
+  },
+});

--- a/src/api/queryClient.js
+++ b/src/api/queryClient.js
@@ -12,3 +12,5 @@ export const queryClient = new QueryClient({
     },
   },
 });
+
+export default queryClient;

--- a/src/api/queryKeys.js
+++ b/src/api/queryKeys.js
@@ -4,6 +4,5 @@ export const QUERY_KEY = {
   // auth
   SIGN_IN: PATH_API.SIGN_IN,
   SIGN_UP: PATH_API.SIGN_UP,
-  SIGN_OUT: PATH_API.SIGN_OUT,
 };
 export default QUERY_KEY;

--- a/src/api/queryKeys.js
+++ b/src/api/queryKeys.js
@@ -1,0 +1,9 @@
+import { PATH_API } from './path';
+
+export const QUERY_KEY = {
+  // auth
+  SIGN_IN: PATH_API.SIGN_IN,
+  SIGN_UP: PATH_API.SIGN_UP,
+  SIGN_OUT: PATH_API.SIGN_OUT,
+};
+export default QUERY_KEY;

--- a/src/api/react-query-provider.jsx
+++ b/src/api/react-query-provider.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useState } from 'react';
+
+export default function ReactQueryProviders({ children }) {
+  const [client] = useState(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          refetchOnWindowFocus: false, // 윈도우가 다시 포커스되었을때 데이터를 refetch
+          refetchOnMount: false, // 데이터가 stale 상태이면 컴포넌트가 마운트될 때 refetch
+          retry: 1, // API 요청 실패시 재시도 하는 옵션 (설정값 만큼 재시도)
+        },
+      },
+    })
+  );
+
+  return (
+    <QueryClientProvider client={client}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/src/api/react-query-provider.jsx
+++ b/src/api/react-query-provider.jsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { useState } from 'react';
 
 export default function ReactQueryProviders({ children }) {
   const [client] = useState(

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,9 @@
 export { default as TeacherHeader } from './header/teacherHeader';
+export { default as DirectorHeader } from './header/directorHeader';
 
 export { default as TeacherSideBar } from './sidebar/teacherSidebar';
 
 export { default as Title } from './textLayout/title';
 
 export { default as Teacher } from './layouts/teacher';
+export { default as Director } from './layouts/director';

--- a/src/components/layouts/director.jsx
+++ b/src/components/layouts/director.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Outlet } from 'react-router-dom';
 
 import { Box } from '@mui/material';
 
@@ -14,11 +15,13 @@ import DirectorHeader from '../header/directorHeader';
  
  */
 
-export default function Director({ children }) {
+export default function Director() {
   return (
     <Box component="main">
       <DirectorHeader />
-      <Box sx={{ py: 2, px: 5 }}>{children}</Box>
+      <Box sx={{ py: 2, px: 5 }}>
+        <Outlet />
+      </Box>
     </Box>
   );
 }

--- a/src/components/layouts/teacher.jsx
+++ b/src/components/layouts/teacher.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Outlet } from 'react-router-dom';
 import { Box, Grid } from '@mui/material';
 import TeacherHeader from '../header/teacherHeader';
 import TeacherSideBar from '../sidebar/teacherSidebar';
@@ -10,10 +11,9 @@ import TeacherSideBar from '../sidebar/teacherSidebar';
  <Teacher>
    Contents
  </Teacher>
-
  */
 
-export default function Teacher({ children }) {
+export default function Teacher() {
   return (
     <Box height="100%">
       <TeacherHeader />
@@ -22,7 +22,7 @@ export default function Teacher({ children }) {
           <TeacherSideBar />
         </Grid>
         <Grid item xs={10}>
-          {children}
+          <Outlet />
         </Grid>
       </Grid>
     </Box>

--- a/src/components/sidebar/teacherSidebar.jsx
+++ b/src/components/sidebar/teacherSidebar.jsx
@@ -14,6 +14,7 @@ export default function TeacherSidebar() {
       <List>
         {items.map((item) => (
           <ListItemButton
+            key={item.name}
             onClick={() => {
               navigate(item.link);
             }}

--- a/src/config/secret.js
+++ b/src/config/secret.js
@@ -1,0 +1,5 @@
+export const SECRET = {
+  server_ip: import.meta.env.VITE_SERVER_IP,
+};
+
+export default SECRET;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,11 +4,14 @@ import { CssBaseline, ThemeProvider } from '@mui/material';
 import theme from '@styles/globalTheme';
 import '@styles/globalStyles.css';
 import App from './App';
+import ReactQueryProviders from './api/react-query-provider';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <ThemeProvider theme={theme}>
     <CssBaseline>
-      <App />
+      <ReactQueryProviders>
+        <App />
+      </ReactQueryProviders>
     </CssBaseline>
   </ThemeProvider>
 );

--- a/src/pages/director/directorHome.jsx
+++ b/src/pages/director/directorHome.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import Director from '../../components/layouts/director';
+import { Director } from '../../components';
 import Title from '../../components/textLayout/title';
 
 export default function DirectorHome() {
   return (
-    <Director>
-      <Title title="원장화면 홈" subtitle="원장화면 홈" />
-    </Director>
+    // <Director>
+    <Title title="원장화면 홈" subtitle="원장화면 홈" />
+    // </Director>
   );
 }

--- a/src/pages/director/manageMembers/manageStudents.jsx
+++ b/src/pages/director/manageMembers/manageStudents.jsx
@@ -28,7 +28,8 @@ export default function ManageStudents() {
   };
 
   return (
-    <Director>
+    // <Director>
+    <>
       <Typography variant="h5" sx={{ mt: 2, mb: 5 }}>
         학생 관리
       </Typography>
@@ -78,6 +79,7 @@ export default function ManageStudents() {
           <Button onClick={handleCloseDialog}>취소</Button>
         </DialogActions>
       </Dialog>
-    </Director>
+    </>
+    // </Director>
   );
 }

--- a/src/pages/director/manageMembers/manageTeachers.jsx
+++ b/src/pages/director/manageMembers/manageTeachers.jsx
@@ -28,7 +28,8 @@ export default function ManageTeachers() {
   };
 
   return (
-    <Director>
+    // <Director>
+    <>
       <Typography variant="h5" sx={{ mt: 2, mb: 5 }}>
         강사 관리
       </Typography>
@@ -89,6 +90,7 @@ export default function ManageTeachers() {
           <Button onClick={handleCloseDialog}>취소</Button>
         </DialogActions>
       </Dialog>
-    </Director>
+    </>
+    // </Director>
   );
 }

--- a/src/pages/director/manageMembers/requestList.jsx
+++ b/src/pages/director/manageMembers/requestList.jsx
@@ -36,7 +36,8 @@ export default function RequestList() {
   };
 
   return (
-    <Director>
+    // <Director>
+    <>
       <Typography variant="h5" sx={{ mt: 2, mb: 5 }}>
         등록 요청 목록
       </Typography>
@@ -80,7 +81,8 @@ export default function RequestList() {
           </Button>
         </DialogActions>
       </Dialog>
-    </Director>
+    </>
+    // </Director>
   );
 }
 

--- a/src/pages/home/teacherHome.jsx
+++ b/src/pages/home/teacherHome.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { Container } from '@mui/material';
-import { Teacher, Title } from '../../components';
+import { Title } from '../../components';
 
 export default function TeacherHome() {
   return (
-    <Teacher>
-      <Container>
-        <Title title="강사화면 타이틀" subtitle="강사화면 섭타이틀" />
-      </Container>
-    </Teacher>
+    <Container>
+      <Title title="강사화면 타이틀" subtitle="강사화면 섭타이틀" />
+    </Container>
   );
 }

--- a/src/pages/login/login.jsx
+++ b/src/pages/login/login.jsx
@@ -4,9 +4,13 @@ import { useNavigate } from 'react-router-dom';
 import { Box, Button, TextField, Link, Grid, Typography, Container, InputAdornment, IconButton } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 
-function Login({ setIsLoggedIn }) {
+import { useLogin } from '../../api/queries/user/useLogin';
+import { PATH } from '../../route/path';
+
+function Login() {
   const navigate = useNavigate();
   const [showPassword, setShowPassword] = useState(false);
+  const loginMutation = useLogin();
 
   const handleClick = () => {
     setShowPassword((prev) => !prev);
@@ -16,12 +20,25 @@ function Login({ setIsLoggedIn }) {
     event.preventDefault();
     const data = new FormData(event.currentTarget);
     console.log({
-      email: data.get('email'),
+      user_id: data.get('userId'),
       password: data.get('password'),
     });
 
-    // 로그인 성공 시
-    setIsLoggedIn(true);
+    loginMutation.mutate(
+      {
+        user_id: data.get('userId'),
+        password: data.get('password'),
+      },
+      {
+        onSuccess: () => {
+          navigate(PATH.root);
+        },
+        onError: (error) => {
+          console.log(error.message);
+        },
+      }
+    );
+
     navigate('/');
   };
 
@@ -67,7 +84,7 @@ function Login({ setIsLoggedIn }) {
             로그인
           </Button>
           <Grid container>
-            <Grid item xs>
+            <Grid item>
               {/* <Link href="#" variant="body2">
                 Forgot password?
               </Link> */}

--- a/src/pages/notFound/notFound.jsx
+++ b/src/pages/notFound/notFound.jsx
@@ -1,7 +1,21 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { Container } from '@mui/material';
+import { Title } from '../../components';
 
-function NotFound() {
-  return <>404 not found</>;
+function NotFound({ path = '/' }) {
+  return (
+    <Container>
+      <Title
+        title="404 not found"
+        subtitle={
+          <>
+            go back to <Link to={path}>Home</Link>
+          </>
+        }
+      />
+    </Container>
+  );
 }
 
 export default NotFound;

--- a/src/route/path.js
+++ b/src/route/path.js
@@ -1,0 +1,7 @@
+export const PATH = {
+  root: '/',
+  SIGNUP: '/signup',
+  LOGIN: '/login',
+};
+
+export default PATH;

--- a/src/route/path.js
+++ b/src/route/path.js
@@ -2,6 +2,7 @@ export const PATH = {
   root: '/',
   SIGNUP: '/signup',
   LOGIN: '/login',
+  TEACHER: { ROOT: '/teacher' },
 };
 
 export default PATH;

--- a/src/route/path.js
+++ b/src/route/path.js
@@ -1,8 +1,22 @@
 export const PATH = {
   root: '/',
-  SIGNUP: '/signup',
-  LOGIN: '/login',
-  TEACHER: { ROOT: '/teacher' },
+  SIGNUP: 'signup',
+  LOGIN: 'login',
+  TEACHER: {
+    ROOT: '/teacher',
+    CLASS: 'class', // 강의목록
+    COUNSELING: 'counseling', // 학생상담
+    NOTICE: 'notice', // 전체공지
+  },
+  DIRECTOR: {
+    ROOT: '/director',
+    MANAGE_MEMBERS: {
+      ROOT: 'manage-members',
+      REQUESTLIST: 'request-list',
+      TEACHERS: 'teachers',
+      STUDENTS: 'students',
+    },
+  },
 };
 
 export default PATH;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,1 @@
+export { default as useUserAuthStore } from './user/userAuthStore';

--- a/src/store/user/userAuthStore.js
+++ b/src/store/user/userAuthStore.js
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+
+// const example_user = {
+//   user_id: 'test_seonu',
+//   academy_id: 'test_academy2',
+//   email: 'seonu2001@naver.com',
+//   birth_date: '2001-11-10T00:00:00.000Z',
+//   user_name: 'test_seonu',
+//   phone_number: '010-9999-9999',
+//   role: 'TEACHER',
+//   image: 'test_seonu.jpg',
+//   userStatus: null
+// };
+
+const UserAuthStore = (set) => ({
+  // State
+  isLoggedIn: false,
+  user: null,
+
+  // Actions
+  login: (userData) => set({ isLoggedIn: true, user: userData }),
+  logout: () => set({ isLoggedIn: false, user: null }),
+  updateUser: (userData) =>
+    set((state) => ({
+      user: { ...state.user, ...userData },
+    })),
+});
+
+const useUserAuthStore = create(
+  persist(devtools(UserAuthStore, 'UserAuthStore'), {
+    name: 'UserAuthStore', // Storage 이름 지정 (default: localStorage)
+  })
+);
+
+export default useUserAuthStore;


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolve #9 
> resolve #14 

## 📝작업 내용
- zustand 설치
    - zustand로 로그인 유지
    - zustand로 유저 정보 저장
- 서버와 api 연동
    - 로그인 api 연동
    - cors 관련 세팅 추가 (credentials -> 리프레시 토큰 setCookie 안되던 에러 해결)
- refactor
    - 중첩라우팅(`<Outlet/>`) 적용
    - NotFound 페이지 개선

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/3bb71a6d-36f8-40de-b49a-24fce5a97aad)
![image](https://github.com/user-attachments/assets/696bcee3-d071-494d-9fc1-e9808638b243)
![image](https://github.com/user-attachments/assets/53207465-125b-46dd-9c20-7ead4a8d267a)

## 💬리뷰 요구사항(선택)
- redux devtools 크롬 확장프로그램으로 zustand 상태 추적 가능
- 중첩 라우팅 가능하도록 리팩토링 했습니다
