### PR TITLE
공지 컴포넌트화

### DIFF
--- a/src/components/header/teacherHeader.jsx
+++ b/src/components/header/teacherHeader.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Avatar, Box, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
+import { useUserAuthStore } from '../../store';
 
 export default function TeacherHeader() {
-  const [name, setname] = useState('확통고수'); // FIXME: 전역변수로 유저정보 저장
+  const { user } = useUserAuthStore();
   const navigate = useNavigate();
 
   return (
@@ -19,7 +20,7 @@ export default function TeacherHeader() {
           AcademyPro
         </Typography>
         <Box display="flex" alignItems="center" gap={1}>
-          <Typography>강사: {name}</Typography>
+          <Typography>강사: {user?.user_name}</Typography>
           <Avatar />
         </Box>
       </Box>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,3 +14,5 @@ export { default as Teacher } from './layouts/teacher';
 export { default as Director } from './layouts/director';
 
 export { default as TransferList } from './transferList';
+
+export { default as Notice } from './notice/notice';

--- a/src/components/notice/notice.jsx
+++ b/src/components/notice/notice.jsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Button, Menu, MenuItem, Dialog, DialogContent, DialogContentText, DialogActions } from '@mui/material';
+import { MoreVert } from '@mui/icons-material';
+
+/**
+ * 공지사항 컴포넌트
+ * 수정 권한에 따라 수정, 삭제 버튼 노출
+ *
+ * @param {List} notices 공지 리스트
+ * @param {boolean} editable 수정권한
+ * @param {string} updateURL 공지 수정 url
+ * @param {Function(id:number)} handleClickDelete 삭제 함수
+ */
+function Notice({
+  notices,
+  editable = true,
+  updateURL,
+  handleClickDelete = (id) => {
+    console.log('delete', id);
+  },
+}) {
+  const navigate = useNavigate();
+  const [anchorEl, setAnchorEl] = useState(null); // anchorEl?.value == 공지 id
+  const [open, setOpen] = useState(false);
+
+  const handleClickMore = (e) => {
+    setAnchorEl(e.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleClickUpdate = () => {
+    handleClose();
+    navigate(`${updateURL}?id=${anchorEl?.value}`);
+  };
+
+  const handleCloseDialog = () => {
+    setOpen(false);
+  };
+  const handleClickDeleteFunc = (e) => {
+    e.preventDefault();
+    handleClose();
+    handleClickDelete(anchorEl?.value);
+    handleCloseDialog();
+  };
+
+  return (
+    <>
+      <TableContainer component={Paper} sx={{ mt: 3, maxHeight: '60vh', width: '70vw' }}>
+        <Table stickyHeader>
+          <TableHead>
+            <TableRow>
+              <TableCell>제목</TableCell>
+              <TableCell align="right">올린 날짜</TableCell>
+              <TableCell align="right">조회수</TableCell>
+              <TableCell align="right" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {notices.map((notice) => (
+              <TableRow key={`${notice.title}_${notice.date}`}>
+                <TableCell>
+                  <Link to={`/director/notice/${notice.id}`}>{notice.title}</Link>
+                </TableCell>
+                <TableCell align="right">{notice.date}</TableCell>
+                <TableCell align="right">{notice.view}</TableCell>
+                {!editable ? null : (
+                  <TableCell align="right">
+                    <IconButton onClick={handleClickMore} value={notice.id}>
+                      <MoreVert />
+                    </IconButton>
+                  </TableCell>
+                )}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+        <MenuItem onClick={handleClickUpdate}>수정</MenuItem>
+        <MenuItem
+          onClick={() => {
+            setOpen(true);
+          }}
+        >
+          삭제
+        </MenuItem>
+      </Menu>
+
+      <Dialog open={open} onClose={handleCloseDialog}>
+        <DialogContent>
+          <DialogContentText color="black">해당 공지사항을 삭제하시겠습니까?</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDialog}>취소</Button>
+          <Button onClick={handleClickDeleteFunc}>삭제</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+export default Notice;

--- a/src/components/notice/notice.jsx
+++ b/src/components/notice/notice.jsx
@@ -11,7 +11,7 @@ import { MoreVert } from '@mui/icons-material';
  * @param {List} notices 공지 리스트
  * @param {boolean} editable 수정권한
  * @param {string} updateURL 공지 수정 url
- * @param {Function(id:number)} handleClickDelete 삭제 함수
+ * @param {Function} handleClickDelete 삭제 함수
  */
 function Notice({
   notices,

--- a/src/components/sidebar/teacherSidebar.jsx
+++ b/src/components/sidebar/teacherSidebar.jsx
@@ -5,9 +5,9 @@ import { useNavigate } from 'react-router-dom';
 export default function TeacherSidebar() {
   const navigate = useNavigate();
   const items = [
-    { name: 'My 강의 목록', link: '/teacher/#' },
-    { name: '학생 상담', link: '/teacher/#' },
-    { name: '전체 공지', link: '/teacher/#' },
+    { name: 'My 강의 목록', link: '/teacher/class' },
+    { name: '학생 상담', link: '/teacher/counseling' },
+    { name: '공지 게시판', link: '/teacher/notice' },
   ];
   return (
     <Box sx={{ backgroundColor: 'lightgrey', height: '100%' }}>

--- a/src/pages/director/notice/directorNotice.jsx
+++ b/src/pages/director/notice/directorNotice.jsx
@@ -1,10 +1,8 @@
-import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
-import { TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Button, Menu, MenuItem, Dialog, DialogContent, DialogContentText, DialogActions } from '@mui/material';
-import { MoreVert } from '@mui/icons-material';
-
-import { TitleMedium, AddButton } from '../../../components';
+import { TitleMedium, Notice, AddButton } from '../../../components';
+import { useUserAuthStore } from '../../../store';
 
 const notices = [
   { id: 1, title: '8월 정기고사 안내', date: '2024-07-20', view: 55 },
@@ -16,79 +14,24 @@ const notices = [
 ];
 
 export default function DirectorNotice() {
+  const { user } = useUserAuthStore();
   const navigate = useNavigate();
-  const [anchorEl, setAnchorEl] = useState(null);
-  const [open, setOpen] = useState(false);
 
   const handleClickAdd = () => {
     navigate('/director/notice/add');
   };
 
-  const handleClickMore = (e) => {
-    setAnchorEl(e.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  const handleClickUpdate = () => {
-    handleClose();
-    navigate('/director/notice/update');
-  };
-  const handleClickDelete = () => {
-    handleClose();
-    setOpen(true);
-  };
-
-  const handleCloseDialog = () => {
-    setOpen(false);
+  const handleClickDelete = (id) => {
+    // TODO: 전체공지 삭제 api 연동
+    console.log('delete', id);
   };
 
   return (
     <>
       <TitleMedium title="전체 공지사항" />
-      <TableContainer component={Paper} sx={{ mt: 3, maxHeight: '60vh', width: '70vw' }}>
-        <Table stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell>제목</TableCell>
-              <TableCell align="right">올린 날짜</TableCell>
-              <TableCell align="right">조회수</TableCell>
-              <TableCell align="right" />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {notices.map((notice) => (
-              <TableRow key={`${notice.title}_${notice.date}`}>
-                <TableCell>
-                  <Link to={`/director/notice/${notice.id}`}>{notice.title}</Link>
-                </TableCell>
-                <TableCell align="right">{notice.date}</TableCell>
-                <TableCell align="right">{notice.view}</TableCell>
-                <TableCell align="right">
-                  <IconButton onClick={handleClickMore}>
-                    <MoreVert />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-        <MenuItem onClick={handleClickUpdate}>수정</MenuItem>
-        <MenuItem onClick={handleClickDelete}>삭제</MenuItem>
-      </Menu>
+      {/* TODO: editable 주석 제거 */}
+      <Notice notices={notices} /* editable={user.role === 'CHIEF'} */ updateURL="/director/notice/update" handleClickDelete={handleClickDelete} />
       <AddButton title="새 공지사항 등록" onClick={handleClickAdd} />
-      <Dialog open={open} onClose={handleCloseDialog}>
-        <DialogContent>
-          <DialogContentText color="black">해당 공지사항을 삭제하시겠습니까?</DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDialog}>취소</Button>
-          <Button onClick={handleCloseDialog}>삭제</Button>
-        </DialogActions>
-      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

resolve #29

## 📝작업 내용
- `Notice` 컴포넌트로 공지 페이지 컴포넌트 분리
    ![image](https://github.com/user-attachments/assets/cf784047-671e-44ec-8cf8-0a9830ed6f9c)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 공지 메뉴 버튼에 value 추가해서 `anchorEl.value` 로 공지 id 에  접근 가능하게 수정했습니다.
- `handleClickDelete` 함수 정의하여 공지 삭제 api 연결할 수 있게 수정했습니다.
    ![image](https://github.com/user-attachments/assets/56f31bea-95c5-4834-a50e-80e717094fe1)

