### PR TITLE
#36 first page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,23 +30,24 @@ import { PATH } from './route/path';
 import { useUserAuthStore } from './store';
 
 function App() {
-  const { isLoggedIn } = useUserAuthStore();
+  const { isLoggedIn, user } = useUserAuthStore();
+  const hasRegistered = user.academy_id !== null && user.academy_id !== undefined;
 
   return (
     <div className="App">
       <BrowserRouter>
         <Routes>
-          <Route path={PATH.root} element={isLoggedIn ? <Register name="홍길동" position="teacher" /> : <FirstPage />} />
+          <Route path={PATH.root} element={<FirstPage />} />
           <Route path={PATH.SIGNUP} element={<SignUp />} />
           <Route path={PATH.LOGIN} element={<Login />} />
 
           <Route path={PATH.TEACHER.ROOT} element={<Teacher />}>
-            <Route path="" element={<TeacherHome />} />
+            <Route path="" element={hasRegistered ? <TeacherHome /> : <Register name={user.user_name} position="teacher" />} />
             <Route path="*" element={<NotFound path={PATH.TEACHER.ROOT} />} />
           </Route>
 
           <Route path={PATH.DIRECTOR.ROOT} element={<Director />}>
-            <Route path="" element={<DirectorHome />} />
+            <Route path="" element={hasRegistered ? <DirectorHome /> : <Register name={user.user_name} position="director" />} />
             <Route path={PATH.DIRECTOR.MANAGE_MEMBERS.ROOT} element={<Outlet />}>
               <Route path={PATH.DIRECTOR.MANAGE_MEMBERS.REQUESTLIST} element={<RequestList />} />
               <Route path={PATH.DIRECTOR.MANAGE_MEMBERS.TEACHERS} element={<ManageTeachers />} />

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -5,6 +5,7 @@ export const PATH_API = {
   // user
   SIGN_IN: '/user/login',
   SIGN_UP: '/user/signup',
+  SIGN_OUT: '/user/logout',
 };
 
 export default PATH_API;

--- a/src/api/queries/user/useLogin.js
+++ b/src/api/queries/user/useLogin.js
@@ -21,7 +21,9 @@ export const useLogin = (options) => {
     onSuccess: (data) => {
       setSession(data.accessToken);
       login({ ...data.user, userStatus: data.userStatus });
-      navigate(PATH.root);
+
+      if (data.user.role === 'CHIEF') navigate(PATH.DIRECTOR.ROOT);
+      else if (data.user.role === 'TEACHER') navigate(PATH.TEACHER.ROOT);
     },
     onError: (error) => {
       console.log('error occurred at useLogin:', error);

--- a/src/api/queries/user/useLogout.js
+++ b/src/api/queries/user/useLogout.js
@@ -1,0 +1,32 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { PATH_API } from '../../path';
+import { axiosInstance } from '../../axios';
+import { QUERY_KEY } from '../../queryKeys';
+import { removeSession } from '../../api_utils';
+import { PATH } from '../../../route/path';
+import { useUserAuthStore } from '../../../store';
+
+const useLogout = (options) => {
+  const navigate = useNavigate();
+  const { logout } = useUserAuthStore();
+
+  return useMutation({
+    mutationKey: [QUERY_KEY.SIGN_OUT],
+    mutationFn: async () => {
+      const response = await axiosInstance.post(PATH_API.SIGN_OUT);
+      return response.data;
+    },
+    onSuccess: () => {
+      removeSession();
+      logout();
+      navigate(PATH.root);
+    },
+    onError: (error) => {
+      console.log('error occurred at useLogout:', error);
+    },
+    ...options,
+  });
+};
+
+export default useLogout;

--- a/src/api/queryKeys.js
+++ b/src/api/queryKeys.js
@@ -4,5 +4,6 @@ export const QUERY_KEY = {
   // auth
   SIGN_IN: PATH_API.SIGN_IN,
   SIGN_UP: PATH_API.SIGN_UP,
+  SIGN_OUT: PATH_API.SIGN_OUT,
 };
 export default QUERY_KEY;

--- a/src/pages/login/login.jsx
+++ b/src/pages/login/login.jsx
@@ -1,18 +1,13 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { Box, Button, TextField, Link, Grid, Typography, Container, InputAdornment, IconButton } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 import { useLogin } from '../../api/queries/user/useLogin';
-import { PATH } from '../../route/path';
-import { useUserAuthStore } from '../../store';
 
 function Login() {
-  const navigate = useNavigate();
   const [showPassword, setShowPassword] = useState(false);
   const loginMutation = useLogin();
-  const { user } = useUserAuthStore();
 
   const handleClick = () => {
     setShowPassword((prev) => !prev);
@@ -26,23 +21,10 @@ function Login() {
       password: data.get('password'),
     });
 
-    loginMutation.mutate(
-      {
-        user_id: data.get('userId'),
-        password: data.get('password'),
-      },
-      {
-        onSuccess: () => {
-          if (user.role === 'DIRECTOR') navigate(PATH.DIRECTOR.ROOT);
-          else if (user.role === 'TEACHER') navigate(PATH.TEACHER.ROOT);
-        },
-        onError: (error) => {
-          console.log(error.message);
-        },
-      }
-    );
-
-    navigate('/');
+    loginMutation.mutate({
+      user_id: data.get('userId'),
+      password: data.get('password'),
+    });
   };
 
   return (

--- a/src/pages/login/login.jsx
+++ b/src/pages/login/login.jsx
@@ -6,11 +6,13 @@ import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 import { useLogin } from '../../api/queries/user/useLogin';
 import { PATH } from '../../route/path';
+import { useUserAuthStore } from '../../store';
 
 function Login() {
   const navigate = useNavigate();
   const [showPassword, setShowPassword] = useState(false);
   const loginMutation = useLogin();
+  const { user } = useUserAuthStore();
 
   const handleClick = () => {
     setShowPassword((prev) => !prev);
@@ -31,7 +33,8 @@ function Login() {
       },
       {
         onSuccess: () => {
-          navigate(PATH.root);
+          if (user.role === 'DIRECTOR') navigate(PATH.DIRECTOR.ROOT);
+          else if (user.role === 'TEACHER') navigate(PATH.TEACHER.ROOT);
         },
         onError: (error) => {
           console.log(error.message);

--- a/src/pages/register/register.jsx
+++ b/src/pages/register/register.jsx
@@ -1,13 +1,21 @@
 import React, { useState } from 'react';
 
 import { Box, Container, Typography, Button, TextField, Grid } from '@mui/material';
+import useLogout from '../../api/queries/user/useLogout';
 
 export default function Register({ name, position }) {
   // 0: 요청 버튼, 1: 학원 등록, 2: 강사 등록
   const [status, setStatus] = useState(0);
+
+  const logoutMutation = useLogout();
+
   const handleClick = () => {
     if (position === 'director') setStatus(1);
     else if (position === 'teacher') setStatus(2);
+  };
+
+  const handleSignOut = () => {
+    logoutMutation.mutate();
   };
 
   return (
@@ -23,7 +31,7 @@ export default function Register({ name, position }) {
         <Typography variant="h4" align="center">
           Academy Pro
         </Typography>
-        {status === 0 && <BeforeRegister name={name} position={position} handleClick={handleClick} />}
+        {status === 0 && <BeforeRegister name={name} position={position} handleClick={handleClick} handleSignOut={handleSignOut} />}
         {status === 1 && <RegisterAcademy />}
         {status === 2 && <RegisterTeacher />}
       </Box>
@@ -31,7 +39,7 @@ export default function Register({ name, position }) {
   );
 }
 
-function BeforeRegister({ name, position, handleClick }) {
+function BeforeRegister({ name, position, handleClick, handleSignOut }) {
   return (
     <Box mt={10} sx={{ width: '100%' }}>
       {position === 'director' && (
@@ -50,6 +58,9 @@ function BeforeRegister({ name, position, handleClick }) {
       )}
       <Button variant="contained" size="large" fullWidth onClick={handleClick}>
         {position === 'director' ? '우리 학원 등록하기' : '학원에 등록 요청하기'}
+      </Button>
+      <Button size="large" fullWidth onClick={handleSignOut}>
+        로그아웃
       </Button>
     </Box>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #36 첫 화면 API 연동

## 📝작업 내용

> 로그아웃 useMutation으로 처리, 등록전화면에서 로그아웃 버튼 추가,
로그인 후 역할에 따라 라우팅, 
등록여부에 따라 등록화면/일반화면 띄우기

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 로그인 성공/에러 처리는 useLogin.js 파일에서만 해주고, login.js 파일에서 해당 useMutation을 사용할 때는 다시 전달하지 않도록 제거했습니다.
