### PR TITLE
#35 director profile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,7 @@ import {
   DirectorProfile,
   DirectorProfileUpdate,
   FindId,
-  DirectorResetPassword,
+  DirectorUpdatePassword,
 } from './pages';
 import { PATH } from './route/path';
 import { useUserAuthStore } from './store';
@@ -106,7 +106,7 @@ function App() {
             <Route path={PATH.DIRECTOR.PROFILE.ROOT} element={<Outlet />}>
               <Route path="" element={<DirectorProfile />} />
               <Route path={PATH.DIRECTOR.PROFILE.UPDATE} element={<DirectorProfileUpdate />} />
-              <Route path={PATH.DIRECTOR.PROFILE.RESET_PW} element={<DirectorResetPassword />} />
+              <Route path={PATH.DIRECTOR.PROFILE.UPDATE_PW} element={<DirectorUpdatePassword />} />
             </Route>
             <Route path="*" element={<NotFound path={PATH.DIRECTOR.ROOT} />} />
           </Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,12 +37,9 @@ import {
   DirectorUpdatePassword,
 } from './pages';
 import { PATH } from './route/path';
-import { useUserAuthStore } from './store';
 import ResetPassword from './pages/login/resetPassword';
 
 function App() {
-  const { user } = useUserAuthStore();
-
   return (
     <div className="App">
       <BrowserRouter>
@@ -55,8 +52,8 @@ function App() {
               <Route path={PATH.LOGIN.FIND_ID} element={<FindId />} />
               <Route path={PATH.LOGIN.RESET_PW} element={<ResetPassword />} />
             </Route>
-            <Route path={PATH.REGISTER_ACADEMY} element={<Register name={user.user_name} position="director" />} />
-            <Route path={PATH.REGISTER_TEACHER} element={<Register name={user.user_name} position="teacher" />} />
+            <Route path={PATH.REGISTER_ACADEMY} element={<Register position="director" />} />
+            <Route path={PATH.REGISTER_TEACHER} element={<Register position="teacher" />} />
           </Route>
 
           <Route path={PATH.TEACHER.ROOT} element={<Teacher />}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ import {
   DirectorProfile,
   DirectorProfileUpdate,
   FindId,
+  DirectorResetPassword,
 } from './pages';
 import { PATH } from './route/path';
 import { useUserAuthStore } from './store';
@@ -105,6 +106,7 @@ function App() {
             <Route path={PATH.DIRECTOR.PROFILE.ROOT} element={<Outlet />}>
               <Route path="" element={<DirectorProfile />} />
               <Route path={PATH.DIRECTOR.PROFILE.UPDATE} element={<DirectorProfileUpdate />} />
+              <Route path={PATH.DIRECTOR.PROFILE.RESET_PW} element={<DirectorResetPassword />} />
             </Route>
             <Route path="*" element={<NotFound path={PATH.DIRECTOR.ROOT} />} />
           </Route>

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -10,6 +10,7 @@ export const PATH_API = {
   CHECK_DUP: '/user/check-id',
   SIGN_OUT: '/user/logout',
   PROFILE_BASIC: (userId) => `/user/${userId}/basic-info`,
+  CANCEL_ACCOUNT: (userId) => `/user/${userId}`,
   // register
   REGISTER_ACADEMY: '/registeration/request/academy',
   REGISTER_TEACHER: '/registeration/request/user',

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -9,6 +9,7 @@ export const PATH_API = {
   SIGN_UP: '/user/signup',
   CHECK_DUP: '/user/check-id',
   SIGN_OUT: '/user/logout',
+  PROFILE_BASIC: (userId) => `/user/${userId}/basic-info`,
   // register
   REGISTER_ACADEMY: '/registeration/request/academy',
   REGISTER_TEACHER: '/registeration/request/user',

--- a/src/api/queries/user/useCancelAccount.js
+++ b/src/api/queries/user/useCancelAccount.js
@@ -1,0 +1,22 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { axiosInstance } from '../../axios';
+import { PATH_API } from '../../path';
+
+export const useCancelAccount = (userId) => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: async () => {
+      const response = await axiosInstance.delete(PATH_API.CANCEL_ACCOUNT(userId));
+      return response.data;
+    },
+    onSuccess: () => {
+      console.log('회원 탈퇴 성공');
+      navigate('/');
+    },
+    onError: (error) => {
+      console.log('Error occurred at useCancelAccount:', error);
+    },
+  });
+};

--- a/src/api/queries/user/useLogin.js
+++ b/src/api/queries/user/useLogin.js
@@ -22,8 +22,10 @@ export const useLogin = (options) => {
       // role 이 STUDENT or PARENT 이면 에러 발생
       if (data.user.role === 'STUDENT' || data.user.role === 'PARENT') throw new Error();
 
-      setSession(data.accessToken);
-      login({ ...data.user, userStatus: data.userStatus });
+      const { user, accessToken } = data;
+      setSession(accessToken);
+      user.birth_date = user.birth_date.substr(0, 10);
+      login({ ...user, userStatus: data.userStatus });
 
       const hasRegistered = data.user.academy_id !== null;
       if (data.user.role === 'CHIEF') {

--- a/src/api/queries/user/useProfile.js
+++ b/src/api/queries/user/useProfile.js
@@ -1,7 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import { PATH_API } from '../../path';
 import { QUERY_KEY } from '../../queryKeys';
 import { axiosInstance } from '../../axios';
+import { useUserAuthStore } from '../../../store';
 
 export const useProfileBasic = (userId) =>
   useQuery({
@@ -15,3 +17,22 @@ export const useProfileBasic = (userId) =>
       return basicInfo;
     },
   });
+
+export const useUpdateProfile = (userId) => {
+  const navigate = useNavigate();
+  const { updateUser } = useUserAuthStore();
+
+  return useMutation({
+    mutationFn: async (data) => {
+      const response = await axiosInstance.put(PATH_API.PROFILE_BASIC(userId), data);
+      return response.data;
+    },
+    onSuccess: (data) => {
+      updateUser(data);
+      navigate('/director/profile');
+    },
+    onError: (error) => {
+      console.log('Error occured at useProfileUpdate: ', error);
+    },
+  });
+};

--- a/src/api/queries/user/useProfile.js
+++ b/src/api/queries/user/useProfile.js
@@ -8,6 +8,10 @@ export const useProfileBasic = (userId) =>
     queryKey: [QUERY_KEY.PROFILE_BASIC(userId)],
     queryFn: async () => {
       const response = await axiosInstance.get(PATH_API.PROFILE_BASIC(userId));
-      return response.data.data;
+      const basicInfo = response.data.data;
+
+      basicInfo.birth_date = basicInfo.birth_date.substr(0, 10);
+      // console.log(basicInfo);
+      return basicInfo;
     },
   });

--- a/src/api/queries/user/useProfile.js
+++ b/src/api/queries/user/useProfile.js
@@ -36,3 +36,21 @@ export const useUpdateProfile = (userId) => {
     },
   });
 };
+
+export const useResetPassword = (userId) => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: async (password) => {
+      const response = await axiosInstance.put(PATH_API.PROFILE_BASIC(userId), { password });
+      return response.data;
+    },
+    onSuccess: () => {
+      alert('비밀번호가 성공적으로 변경되었습니다!');
+      navigate('/director/profile');
+    },
+    onError: (error) => {
+      console.log('Error occured at useResetPassword: ', error);
+    },
+  });
+};

--- a/src/api/queries/user/useProfile.js
+++ b/src/api/queries/user/useProfile.js
@@ -37,7 +37,7 @@ export const useUpdateProfile = (userId) => {
   });
 };
 
-export const useResetPassword = (userId) => {
+export const useUpdatePassword = (userId) => {
   const navigate = useNavigate();
 
   return useMutation({
@@ -50,7 +50,7 @@ export const useResetPassword = (userId) => {
       navigate('/director/profile');
     },
     onError: (error) => {
-      console.log('Error occured at useResetPassword: ', error);
+      console.log('Error occured at useUpdatePassword: ', error);
     },
   });
 };

--- a/src/api/queries/user/useProfile.js
+++ b/src/api/queries/user/useProfile.js
@@ -8,12 +8,6 @@ export const useProfileBasic = (userId) =>
     queryKey: [QUERY_KEY.PROFILE_BASIC(userId)],
     queryFn: async () => {
       const response = await axiosInstance.get(PATH_API.PROFILE_BASIC(userId));
-      return response.data;
-    },
-    onSuccess: (data) => {
-      console.log(data);
-    },
-    onError: (error) => {
-      console.log('Error occured at useProfile:', error);
+      return response.data.data;
     },
   });

--- a/src/api/queries/user/useProfile.js
+++ b/src/api/queries/user/useProfile.js
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { PATH_API } from '../../path';
+import { QUERY_KEY } from '../../queryKeys';
+import { axiosInstance } from '../../axios';
+
+export const useProfileBasic = (userId) =>
+  useQuery({
+    queryKey: [QUERY_KEY.PROFILE_BASIC(userId)],
+    queryFn: async () => {
+      const response = await axiosInstance.get(PATH_API.PROFILE_BASIC(userId));
+      return response.data;
+    },
+    onSuccess: (data) => {
+      console.log(data);
+    },
+    onError: (error) => {
+      console.log('Error occured at useProfile:', error);
+    },
+  });

--- a/src/api/queryClient.js
+++ b/src/api/queryClient.js
@@ -1,6 +1,11 @@
-import { QueryClient } from '@tanstack/react-query';
+import { QueryClient, QueryCache } from '@tanstack/react-query';
 
 export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error) => {
+      console.log('Error occured at useQuery:', error);
+    },
+  }),
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false, // 브라우저에 포커스가 들어온 경우

--- a/src/api/queryKeys.js
+++ b/src/api/queryKeys.js
@@ -5,5 +5,6 @@ export const QUERY_KEY = {
   SIGN_IN: PATH_API.SIGN_IN,
   SIGN_UP: PATH_API.SIGN_UP,
   SIGN_OUT: PATH_API.SIGN_OUT,
+  PROFILE_BASIC: (userId) => PATH_API.PROFILE_BASIC(userId),
 };
 export default QUERY_KEY;

--- a/src/components/dialog/simpleDialog.jsx
+++ b/src/components/dialog/simpleDialog.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText } from '@mui/material';
+
+/**
+ * 첫번째 버튼은 취소, 두 번째 버튼은 사용자 지정 행위를 하는 다이얼로그
+ * @param {String} second - 두 번째 버튼에 넣을 텍스트
+ */
+
+export default function TwoButtonDialog({ openDialog, handleClose, text, second, handleClickSecond }) {
+  return (
+    <Dialog open={openDialog} onClose={handleClose}>
+      <DialogContent>
+        <DialogContentText color="black">{text}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>취소</Button>
+        <Button onClick={handleClickSecond}>{second}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/header/directorHeader.jsx
+++ b/src/components/header/directorHeader.jsx
@@ -2,12 +2,16 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Box, Typography, AppBar, Toolbar, Button, IconButton, Avatar, Menu, MenuItem } from '@mui/material';
+import useLogout from '../../api/queries/user/useLogout';
 
 export default function DirectorHeader() {
   const navigate = useNavigate();
 
+  const logoutMutation = useLogout();
+
   const [anchorEl, setAnchorEl] = useState(null);
   const [anchorEl2, setAnchorEl2] = useState(null);
+  const [anchorEl3, setAnchorEl3] = useState(null);
 
   const handleMouseOver = (e) => {
     setAnchorEl(e.currentTarget);
@@ -21,6 +25,18 @@ export default function DirectorHeader() {
   const handleClose2 = () => {
     setAnchorEl2(null);
   };
+  const handleMouseOver3 = (e) => {
+    setAnchorEl3(e.currentTarget);
+  };
+  const handleClose3 = () => {
+    setAnchorEl3(null);
+  };
+
+  const handleLogout = () => {
+    handleClose3();
+    logoutMutation.mutate();
+  };
+
   return (
     <AppBar position="fixed">
       <Toolbar>
@@ -100,9 +116,20 @@ export default function DirectorHeader() {
             전체 공지
           </Button>
         </Box>
-        <IconButton onClick={() => navigate('/director/profile')}>
+        <IconButton onMouseOver={handleMouseOver3}>
           <Avatar />
         </IconButton>
+        <Menu anchorEl={anchorEl3} open={Boolean(anchorEl3)} onClose={handleClose3}>
+          <MenuItem
+            onClick={() => {
+              handleClose3();
+              navigate('/director/profile');
+            }}
+          >
+            프로필 보기
+          </MenuItem>
+          <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
+        </Menu>
       </Toolbar>
     </AppBar>
   );

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -11,6 +11,8 @@ export { default as SubmitButtons } from './button/submitButtons';
 export { default as AddButton } from './button/addButton';
 export { default as CustomLink } from './button/customLink';
 
+export { default as SimpleDialog } from './dialog/simpleDialog';
+
 export { default as Teacher } from './layouts/teacher';
 export { default as Director } from './layouts/director';
 

--- a/src/pages/director/manageMembers/requestList.jsx
+++ b/src/pages/director/manageMembers/requestList.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
-import { Typography, List, ListItem, ListItemText, Button, Grid, Dialog, DialogActions, DialogContent } from '@mui/material';
-import { TitleMedium } from '../../../components';
+import { Typography, List, ListItem, ListItemText, Button, Grid } from '@mui/material';
+import { SimpleDialog, TitleMedium } from '../../../components';
 
 const teachers = [
   { name: '나미리', lectures: ['화법과 작문', '비문학'] },
@@ -59,24 +59,9 @@ export default function RequestList() {
           </List>
         </Grid>
       </Grid>
-      <Dialog open={openApprove} onClose={handleCloseApprove}>
-        <DialogContent>나미리님의 등록 요청을 승인하시겠습니까?</DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseApprove}>승인</Button>
-          <Button onClick={handleCloseApprove} autoFocus>
-            취소
-          </Button>
-        </DialogActions>
-      </Dialog>
-      <Dialog open={openDecline} onClose={handleCloseDecline}>
-        <DialogContent>나미리님의 등록 요청을 거절하시겠습니까?</DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDecline}>거절</Button>
-          <Button onClick={handleCloseDecline} autoFocus>
-            취소
-          </Button>
-        </DialogActions>
-      </Dialog>
+
+      <SimpleDialog openDialog={openApprove} handleClose={handleCloseApprove} text="나미리님의 등록 요청을 승인하시겠습니까?" second="승인" handleClickSecond={handleCloseApprove} />
+      <SimpleDialog openDialog={openDecline} handleClose={handleCloseDecline} text="나미리님의 등록 요청을 거절하시겠습니까?" second="거절" handleClickSecond={handleCloseDecline} />
     </>
   );
 }

--- a/src/pages/director/profile/directorProfile.jsx
+++ b/src/pages/director/profile/directorProfile.jsx
@@ -3,7 +3,10 @@ import { useNavigate } from 'react-router-dom';
 
 import { Avatar, Box, Container, Grid, IconButton, Typography } from '@mui/material';
 import { Edit } from '@mui/icons-material';
+
 import { useUserAuthStore } from '../../../store';
+import { CustomLink } from '../../../components';
+import { PATH } from '../../../route/path';
 
 // 회원 basic info
 // {
@@ -54,6 +57,9 @@ export default function DirectorProfile() {
             <Typography variant="body1">주소: 서울특별시 서초구 서초1동 ...</Typography>
             <Typography variant="body1">이메일: tteokip@gmail.com</Typography>
           </Box>
+        </Grid>
+        <Grid item xs={6}>
+          <CustomLink to={PATH.DIRECTOR.PROFILE.RESET_PW} text="비밀번호 변경" />
         </Grid>
       </Grid>
     </Container>

--- a/src/pages/director/profile/directorProfile.jsx
+++ b/src/pages/director/profile/directorProfile.jsx
@@ -3,9 +3,27 @@ import { useNavigate } from 'react-router-dom';
 
 import { Avatar, Box, Container, Grid, IconButton, Typography } from '@mui/material';
 import { Edit } from '@mui/icons-material';
+import { useProfileBasic } from '../../../api/queries/user/useProfile';
+import { useUserAuthStore } from '../../../store';
+
+// 회원 basic info
+// {
+//   "user_id": "string",
+//   "academy_id": "string",
+//   "email": "user@example.com",
+//   "birth_date": "2024-10-11",
+//   "user_name": "string",
+//   "phone_number": "string",
+//   "role": "string",
+//   "image": "string",
+//   "family": "string"
+// }
 
 export default function DirectorProfile() {
   const navigate = useNavigate();
+  const { user } = useUserAuthStore();
+
+  const { data: basicInfo } = useProfileBasic(user.user_id);
 
   const handleClickUpdate = () => {
     navigate('/director/profile/update');
@@ -18,7 +36,7 @@ export default function DirectorProfile() {
           <Avatar sx={{ width: 100, height: 100 }} />
         </Grid>
         <Grid item xs={8} sx={{ display: 'flex', alignItems: 'center' }}>
-          <Typography variant="h6">권지옹 원장</Typography>
+          <Typography variant="h6">{basicInfo?.user_name} 원장</Typography>
           <IconButton sx={{ m: 2 }} onClick={handleClickUpdate}>
             <Edit />
           </IconButton>
@@ -26,9 +44,9 @@ export default function DirectorProfile() {
         <Grid item xs={12}>
           <Typography variant="h6">개인 정보</Typography>
           <Box sx={{ p: 2, backgroundColor: 'lightgray' }}>
-            <Typography variant="body1">생년월일: 1963.10.24</Typography>
-            <Typography variant="body1">전화번호: 010-9393-2929</Typography>
-            <Typography variant="body1">이메일: geedragon@gmail.com</Typography>
+            <Typography variant="body1">생년월일: {basicInfo?.birth_date}</Typography>
+            <Typography variant="body1">전화번호: {basicInfo?.phone_number}</Typography>
+            <Typography variant="body1">이메일: {basicInfo?.email}</Typography>
           </Box>
         </Grid>
         <Grid item xs={12}>

--- a/src/pages/director/profile/directorProfile.jsx
+++ b/src/pages/director/profile/directorProfile.jsx
@@ -59,7 +59,7 @@ export default function DirectorProfile() {
           </Box>
         </Grid>
         <Grid item xs={6}>
-          <CustomLink to={PATH.DIRECTOR.PROFILE.RESET_PW} text="비밀번호 변경" />
+          <CustomLink to={PATH.DIRECTOR.PROFILE.UPDATE_PW} text="비밀번호 변경" />
         </Grid>
       </Grid>
     </Container>

--- a/src/pages/director/profile/directorProfile.jsx
+++ b/src/pages/director/profile/directorProfile.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { Avatar, Box, Container, Grid, IconButton, Typography } from '@mui/material';
 import { Edit } from '@mui/icons-material';
-import { useProfileBasic } from '../../../api/queries/user/useProfile';
 import { useUserAuthStore } from '../../../store';
 
 // 회원 basic info
@@ -23,8 +22,6 @@ export default function DirectorProfile() {
   const navigate = useNavigate();
   const { user } = useUserAuthStore();
 
-  const { data: basicInfo } = useProfileBasic(user.user_id);
-
   const handleClickUpdate = () => {
     navigate('/director/profile/update');
   };
@@ -36,7 +33,7 @@ export default function DirectorProfile() {
           <Avatar sx={{ width: 100, height: 100 }} />
         </Grid>
         <Grid item xs={8} sx={{ display: 'flex', alignItems: 'center' }}>
-          <Typography variant="h6">{basicInfo?.user_name} 원장</Typography>
+          <Typography variant="h6">{user.user_name} 원장</Typography>
           <IconButton sx={{ m: 2 }} onClick={handleClickUpdate}>
             <Edit />
           </IconButton>
@@ -44,9 +41,9 @@ export default function DirectorProfile() {
         <Grid item xs={12}>
           <Typography variant="h6">개인 정보</Typography>
           <Box sx={{ p: 2, backgroundColor: 'lightgray' }}>
-            <Typography variant="body1">생년월일: {basicInfo?.birth_date}</Typography>
-            <Typography variant="body1">전화번호: {basicInfo?.phone_number}</Typography>
-            <Typography variant="body1">이메일: {basicInfo?.email}</Typography>
+            <Typography variant="body1">생년월일: {user.birth_date}</Typography>
+            <Typography variant="body1">전화번호: {user.phone_number}</Typography>
+            <Typography variant="body1">이메일: {user.email}</Typography>
           </Box>
         </Grid>
         <Grid item xs={12}>

--- a/src/pages/director/profile/resetPassword.jsx
+++ b/src/pages/director/profile/resetPassword.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+
+import { Container, Box, TextField, InputAdornment, IconButton, Button } from '@mui/material';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
+
+import { TitleMedium } from '../../../components';
+
+export default function ResetPassword() {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleClick = () => {
+    setShowPassword(!showPassword);
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+  };
+
+  return (
+    <Container sx={{ width: '50vw', p: 5 }}>
+      <Box component="form" onSubmit={handleSubmit}>
+        <TitleMedium title="비밀번호 변경" />
+        <TextField
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton onClick={handleClick} edge="end">
+                  {showPassword ? <Visibility /> : <VisibilityOff />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+          type={showPassword ? 'text' : 'password'}
+          name="password"
+          label="비밀번호"
+          required
+          fullWidth
+          sx={{ my: 1 }}
+        />
+        <TextField
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton onClick={handleClick} edge="end">
+                  {showPassword ? <Visibility /> : <VisibilityOff />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+          type={showPassword ? 'text' : 'password'}
+          name="password2"
+          label="비밀번호 재입력"
+          required
+          fullWidth
+          sx={{ my: 1 }}
+        />
+        <Button type="submit" variant="contained" fullWidth sx={{ mt: 3 }}>
+          확인
+        </Button>
+      </Box>
+    </Container>
+  );
+}

--- a/src/pages/director/profile/resetPassword.jsx
+++ b/src/pages/director/profile/resetPassword.jsx
@@ -1,12 +1,19 @@
 import React, { useState } from 'react';
 
-import { Container, Box, TextField, InputAdornment, IconButton, Button } from '@mui/material';
+import { Container, Box, TextField, InputAdornment, IconButton, Button, Alert } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 import { TitleMedium } from '../../../components';
+import { useResetPassword } from '../../../api/queries/user/useProfile';
+import { useUserAuthStore } from '../../../store';
 
 export default function ResetPassword() {
+  const { user } = useUserAuthStore();
   const [showPassword, setShowPassword] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const resetPwMutation = useResetPassword(user.user_id);
 
   const handleClick = () => {
     setShowPassword(!showPassword);
@@ -14,6 +21,21 @@ export default function ResetPassword() {
 
   const handleSubmit = (event) => {
     event.preventDefault();
+
+    const data = new FormData(event.currentTarget);
+    const password = data.get('password');
+    const password2 = data.get('password2');
+
+    if (password !== password2) {
+      setIsError(true);
+      setErrorMsg('입력하신 두 비밀번호가 일치하지 않습니다.');
+    } else
+      resetPwMutation.mutate(password, {
+        onError: () => {
+          setIsError(true);
+          setErrorMsg('서버 오류로 비밀번호 변경에 실패하였습니다. \n나중에 다시 시도해주세요.');
+        },
+      });
   };
 
   return (
@@ -36,26 +58,12 @@ export default function ResetPassword() {
           required
           fullWidth
           sx={{ my: 1 }}
+          error={isError}
         />
-        <TextField
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                <IconButton onClick={handleClick} edge="end">
-                  {showPassword ? <Visibility /> : <VisibilityOff />}
-                </IconButton>
-              </InputAdornment>
-            ),
-          }}
-          type={showPassword ? 'text' : 'password'}
-          name="password2"
-          label="비밀번호 재입력"
-          required
-          fullWidth
-          sx={{ my: 1 }}
-        />
-        <Button type="submit" variant="contained" fullWidth sx={{ mt: 3 }}>
-          확인
+        <TextField type="password" name="password2" label="비밀번호 재입력" required fullWidth sx={{ my: 1 }} error={isError} />
+        {isError && <Alert severity="error">{errorMsg}</Alert>}
+        <Button type="submit" variant="contained" size="large" fullWidth sx={{ mt: 3 }}>
+          변경하기
         </Button>
       </Box>
     </Container>

--- a/src/pages/director/profile/updatePassword.jsx
+++ b/src/pages/director/profile/updatePassword.jsx
@@ -4,16 +4,16 @@ import { Container, Box, TextField, InputAdornment, IconButton, Button, Alert } 
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 import { TitleMedium } from '../../../components';
-import { useResetPassword } from '../../../api/queries/user/useProfile';
+import { useUpdatePassword } from '../../../api/queries/user/useProfile';
 import { useUserAuthStore } from '../../../store';
 
-export default function ResetPassword() {
+export default function UpdatePassword() {
   const { user } = useUserAuthStore();
   const [showPassword, setShowPassword] = useState(false);
   const [isError, setIsError] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
 
-  const resetPwMutation = useResetPassword(user.user_id);
+  const updatePwMutation = useUpdatePassword(user.user_id);
 
   const handleClick = () => {
     setShowPassword(!showPassword);
@@ -30,7 +30,7 @@ export default function ResetPassword() {
       setIsError(true);
       setErrorMsg('입력하신 두 비밀번호가 일치하지 않습니다.');
     } else
-      resetPwMutation.mutate(password, {
+      updatePwMutation.mutate(password, {
         onError: () => {
           setIsError(true);
           setErrorMsg('서버 오류로 비밀번호 변경에 실패하였습니다. \n나중에 다시 시도해주세요.');

--- a/src/pages/director/profile/updateProfile.jsx
+++ b/src/pages/director/profile/updateProfile.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Box, Button, Container, TextField, Typography, Grid, Avatar } from '@mui/material';
+import { Box, Button, Container, TextField, Typography, Grid, Avatar, Dialog, DialogContent, DialogContentText, DialogActions } from '@mui/material';
 import dayjs from 'dayjs';
 import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -10,6 +10,7 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { SubmitButtons } from '../../../components';
 import { useUpdateProfile } from '../../../api/queries/user/useProfile';
 import { useUserAuthStore } from '../../../store';
+import { useCancelAccount } from '../../../api/queries/user/useCancelAccount';
 
 const directorProfile = {
   personal: {
@@ -60,8 +61,17 @@ function CheckPasswd({ setPassed }) {
 function UpdateProfileForm({ currentInfo }) {
   const { user } = useUserAuthStore();
   const [date, setDate] = useState(dayjs(user.birth_date));
+  const [open, setOpen] = useState(false);
 
   const updateProfileMutation = useUpdateProfile(user.user_id);
+  const cancelAccountMutation = useCancelAccount(user.user_id);
+
+  const handleOpenDialog = () => {
+    setOpen(true);
+  };
+  const handleCloseDialog = () => {
+    setOpen(false);
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -76,6 +86,12 @@ function UpdateProfileForm({ currentInfo }) {
 
     // console.log(submitData);
     updateProfileMutation.mutate(submitData);
+  };
+
+  // 회원 탈퇴
+  const handleCancelAccount = () => {
+    handleCloseDialog();
+    cancelAccountMutation.mutate();
   };
 
   return (
@@ -112,6 +128,18 @@ function UpdateProfileForm({ currentInfo }) {
           <TextField label="이메일" defaultValue={currentInfo.academy.email} required fullWidth sx={{ mb: 2 }} />
         </Grid>
       </Grid>
+      <Button sx={{ mt: 3 }} onClick={handleOpenDialog}>
+        회원 탈퇴
+      </Button>
+      <Dialog open={open} onClose={handleCloseDialog}>
+        <DialogContent>
+          <DialogContentText color="black">정말로 탈퇴하시겠습니까?</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDialog}>취소</Button>
+          <Button onClick={handleCancelAccount}>탈퇴</Button>
+        </DialogActions>
+      </Dialog>
       <SubmitButtons submitTitle="수정 완료" />
     </Box>
   );

--- a/src/pages/director/profile/updateProfile.jsx
+++ b/src/pages/director/profile/updateProfile.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { Box, Button, Container, TextField, Typography, Grid, Avatar } from '@mui/material';
 import dayjs from 'dayjs';
@@ -9,6 +8,8 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 import { SubmitButtons } from '../../../components';
+import { useUpdateProfile } from '../../../api/queries/user/useProfile';
+import { useUserAuthStore } from '../../../store';
 
 const directorProfile = {
   personal: {
@@ -57,15 +58,23 @@ function CheckPasswd({ setPassed }) {
 }
 
 function UpdateProfileForm({ currentInfo }) {
-  const navigate = useNavigate();
-  const [date, setDate] = useState(dayjs(currentInfo.personal.birthdate));
+  const { user } = useUserAuthStore();
+  const [date, setDate] = useState(dayjs(user.birth_date));
+
+  const updateProfileMutation = useUpdateProfile(user.user_id);
 
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    // 프로필 수정 요청
+    const data = new FormData(e.currentTarget);
+    const submitData = {
+      user_name: data.get('user_name'),
+      phone_number: data.get('phone_number'),
+      email: data.get('email'),
+    };
 
-    navigate('/director/profile');
+    // console.log(submitData);
+    updateProfileMutation.mutate(submitData);
   };
 
   return (
@@ -78,7 +87,7 @@ function UpdateProfileForm({ currentInfo }) {
           <Avatar sx={{ width: 100, height: 100 }} />
         </Grid>
         <Grid item xs={8} sx={{ display: 'flex', alignItems: 'center' }}>
-          <TextField label="이름" defaultValue={currentInfo.personal.name} required />
+          <TextField label="이름" name="user_name" defaultValue={user.user_name} required />
         </Grid>
         <Grid item xs={12}>
           <Typography variant="h6" sx={{ mb: 2 }}>
@@ -89,8 +98,8 @@ function UpdateProfileForm({ currentInfo }) {
               <DatePicker label="생년월일" maxDate={dayjs()} value={date} onChange={(newValue) => setDate(newValue)} />
             </DemoContainer>
           </LocalizationProvider>
-          <TextField label="전화번호" defaultValue={currentInfo.personal.phone} required fullWidth sx={{ mb: 2 }} />
-          <TextField label="이메일" defaultValue={currentInfo.personal.email} required fullWidth sx={{ mb: 2 }} />
+          <TextField label="전화번호" name="phone_number" defaultValue={user.phone_number} required fullWidth sx={{ mb: 2 }} />
+          <TextField label="이메일" name="email" defaultValue={user.email} required fullWidth sx={{ mb: 2 }} />
         </Grid>
         <Grid item xs={12}>
           <Typography variant="h6" sx={{ mb: 2 }}>

--- a/src/pages/director/profile/updateProfile.jsx
+++ b/src/pages/director/profile/updateProfile.jsx
@@ -71,6 +71,7 @@ function UpdateProfileForm({ currentInfo }) {
       user_name: data.get('user_name'),
       phone_number: data.get('phone_number'),
       email: data.get('email'),
+      birth_date: date.toISOString(),
     };
 
     // console.log(submitData);

--- a/src/pages/director/profile/updateProfile.jsx
+++ b/src/pages/director/profile/updateProfile.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Box, Button, Container, TextField, Typography, Grid, Avatar, Dialog, DialogContent, DialogContentText, DialogActions, Snackbar, IconButton, Icon } from '@mui/material';
+import { Box, Button, Container, TextField, Typography, Grid, Avatar, Snackbar, IconButton } from '@mui/material';
 import { Close } from '@mui/icons-material';
 import dayjs from 'dayjs';
 import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
@@ -8,7 +8,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
-import { SubmitButtons } from '../../../components';
+import { SimpleDialog, SubmitButtons } from '../../../components';
 import { useUpdateProfile } from '../../../api/queries/user/useProfile';
 import { useUserAuthStore } from '../../../store';
 import { useCancelAccount } from '../../../api/queries/user/useCancelAccount';
@@ -151,15 +151,7 @@ function UpdateProfileForm({ currentInfo }) {
       <Button sx={{ mt: 3 }} onClick={handleOpenDialog}>
         회원 탈퇴
       </Button>
-      <Dialog open={openDialog} onClose={handleCloseDialog}>
-        <DialogContent>
-          <DialogContentText color="black">정말로 탈퇴하시겠습니까?</DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDialog}>취소</Button>
-          <Button onClick={handleCancelAccount}>탈퇴</Button>
-        </DialogActions>
-      </Dialog>
+      <SimpleDialog openDialog={openDialog} handleClose={handleCloseDialog} text="정말로 탈퇴하시겠습니까?" second="탈퇴" handleClickSecond={handleCancelAccount} />
       <Snackbar
         open={openSnackbar}
         autoHideDuration={5000}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -38,3 +38,4 @@ export { default as NoticeDetails } from './director/notice/noticeDetails';
 
 export { default as DirectorProfile } from './director/profile/directorProfile';
 export { default as DirectorProfileUpdate } from './director/profile/updateProfile';
+export { default as DirectorResetPassword } from './director/profile/resetPassword';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -38,4 +38,4 @@ export { default as NoticeDetails } from './director/notice/noticeDetails';
 
 export { default as DirectorProfile } from './director/profile/directorProfile';
 export { default as DirectorProfileUpdate } from './director/profile/updateProfile';
-export { default as DirectorResetPassword } from './director/profile/resetPassword';
+export { default as DirectorUpdatePassword } from './director/profile/updatePassword';

--- a/src/pages/register/register.jsx
+++ b/src/pages/register/register.jsx
@@ -5,7 +5,7 @@ import useLogout from '../../api/queries/user/useLogout';
 import { useUserAuthStore } from '../../store';
 import { useRegisterAcademy, useRegisterTeacher } from '../../api/queries/register/useRegister';
 
-export default function Register({ name, position }) {
+export default function Register({ position }) {
   // 0: 요청 버튼, 1: 학원 등록, 2: 강사 등록, 3: 등록요청 완료
   const [status, setStatus] = useState(0);
 
@@ -33,7 +33,7 @@ export default function Register({ name, position }) {
         <Typography variant="h4" align="center">
           Academy Pro
         </Typography>
-        {status === 0 && <BeforeRegister name={name} position={position} handleClick={handleClick} handleSignOut={handleSignOut} />}
+        {status === 0 && <BeforeRegister position={position} handleClick={handleClick} handleSignOut={handleSignOut} />}
         {status === 1 && <RegisterAcademy setStatus={setStatus} handleSignOut={handleSignOut} />}
         {status === 2 && <RegisterTeacher setStatus={setStatus} handleSignOut={handleSignOut} />}
         {status === 3 && <AfterRegister handleSignOut={handleSignOut} />}
@@ -42,19 +42,21 @@ export default function Register({ name, position }) {
   );
 }
 
-function BeforeRegister({ name, position, handleClick, handleSignOut }) {
+function BeforeRegister({ position, handleClick, handleSignOut }) {
+  const { user } = useUserAuthStore();
+
   return (
     <Box mt={10} sx={{ width: '100%' }}>
       {position === 'director' && (
         <Typography variant="h5" align="center" mb={20}>
-          {name}(원장)님,
+          {user.user_name}(원장)님,
           <br />
           학원을 등록해주세요.
         </Typography>
       )}
       {position === 'teacher' && (
         <Typography variant="h5" align="center" mb={20}>
-          {name}(강사)님,
+          {user.user_name}(강사)님,
           <br />
           근무하고 계신 학원에 강사 등록을 요청하세요.
         </Typography>

--- a/src/route/path.js
+++ b/src/route/path.js
@@ -33,6 +33,7 @@ export const PATH = {
     PROFILE: {
       ROOT: 'profile',
       UPDATE: 'update',
+      RESET_PW: 'reset-password',
     },
     MANAGE_MEMBERS: {
       ROOT: 'manage-members',

--- a/src/route/path.js
+++ b/src/route/path.js
@@ -33,7 +33,7 @@ export const PATH = {
     PROFILE: {
       ROOT: 'profile',
       UPDATE: 'update',
-      RESET_PW: 'reset-password',
+      UPDATE_PW: 'update-password',
     },
     MANAGE_MEMBERS: {
       ROOT: 'manage-members',


### PR DESCRIPTION
## #️⃣연관된 이슈

> #35 원장 프로필 페이지 api 연동

## 📝작업 내용

> 원장 기본정보에 대해서 프로필 보기, 수정 구현 (프로필사진, 학원정보는 백엔드 개발 완료되면)
원장 비밀번호 변경 구현
원장 로그아웃/탈퇴 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 아직 #35 완성은 아니고 중도 풀리퀘합니다..

- 프로필 정보 가져오는 useProfileBasic(useProfile.js) 만들어두긴 했는데 로그인 시 회원정보 useUserAuthStore에 저장하므로 거기서 가져와서 띄우고 useProfileBasic 사용하지는 않았습니다.
- 생년월일은 로그인 api 응답받을 때 리액트쿼리에서 뒷부분 잘라서 처리해주도록 했습니다. (ISOString 형태 그대로 처리할 시 datepicker에서 날짜가 이상해짐..)
- 기본 다이얼로그(텍스트, 버튼 2개) 사용 시 SimpleDialog 사용 바랍니다!
