### PR TITLE
feat: 토큰 재발급 코드 주석처리 해제, 리프레시 토큰은 쿠키에서 전송 #45

### DIFF
--- a/src/api/api_utils.js
+++ b/src/api/api_utils.js
@@ -78,8 +78,7 @@ export const tokenExpired = (exp) => {
 
   const currentTime = Date.now();
 
-  // 만료 되기 5분 전에 토큰 갱신
-  // Test token expires after 10s
+  // 만료되기까지 남은 시간
   const timeLeft = exp * 1000 - currentTime;
 
   clearTimeout(expiredTimer);

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 import { PATH_API } from './path';
-import { PATH } from '../route/path';
 
 const TIMEOUT_TIME = 10_000;
 
@@ -47,37 +46,23 @@ axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
     // invalid token
-    const originalRequest = error.config;
-    /* eslint-disable no-underscore-dangle */
-    if (error.response.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
+    // const originalRequest = error.config;
+    // /* eslint-disable no-underscore-dangle */
+    // if (error.response.status === 401 && !originalRequest._retry) {
+    //   originalRequest._retry = true;
 
-      //   const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY!);
+    //   // 리프레시 토큰도 만료된 경우 로그아웃 처리
+    //   alert('system.axios-401-error');
+    //   localStorage.removeItem('accessToken');
+    //   delete originalRequest.Authorization;
 
-      // if (refreshToken) {
-      //   try {
-      //     const response = await axiosInstance.post(PATH_API.TOKEN_REISSUE, {
-      //       refreshToken,
-      //     });
-      //     const newAccessToken = response.data.accessToken;
-      //     localStorage.setItem(ACCESS_TOKEN_KEY!, newAccessToken);
-
-      //     // axiosInstance.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
-      //     originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-      //     return await axiosInstance(originalRequest);
-      //   } catch {
-      // 리프레시 토큰도 만료된 경우 로그아웃 처리
-      alert('system.axios-401-error');
-      localStorage.removeItem('accessToken');
-      delete originalRequest.Authorization;
-
-      // window.location.reload();
-      window.location.href = PATH.root;
-      // Promise.resolve('Error! failed token refresh');
-      // }
-      // }
-    }
-    /* eslint-enable no-underscore-dangle */
+    //   // window.location.reload();
+    //   window.location.href = PATH.root;
+    //   // Promise.resolve('Error! failed token refresh');
+    //   // }
+    //   // }
+    // }
+    // /* eslint-enable no-underscore-dangle */
 
     // timeout
     if (axios.isCancel(error)) {

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -7,6 +7,12 @@ export const PATH_API = {
   SIGN_UP: '/user/signup',
   CHECK_DUP: '/user/check-id',
   SIGN_OUT: '/user/logout',
+  REISSUE_TOKEN: '/user/refresh-token',
+  PROFILE_BASIC: (userId) => `/user/${userId}/basic-info`,
+  CANCEL_ACCOUNT: (userId) => `/user/${userId}`,
+  // register
+  REGISTER_ACADEMY: '/registeration/request/academy',
+  REGISTER_TEACHER: '/registeration/request/user',
 };
 
 export default PATH_API;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #45 액세스 토큰 갱신 api 연동

## 📝작업 내용

> 기존에 api_utils.js에 토큰 재발급받는 코드가 있어서 주석 처리 해제했고 수정할 사항들 수정했습니다.

- 로그인 시 발급받은 액세스 토큰이 만료될 때 자동으로 액세스 토큰 재발급을 요청합니다. 
- 저희 서비스의 경우 리프레시 토큰을 쿠키에 저장하므로 토큰 재발급 함수에 리프레시 토큰 관련한 코드 모두 제거했습니다.
- 리프레시 토큰도 만료되어 액세스 토큰 재발급에 실패했다면 로그아웃 처리하도록 했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
