### PR TITLE
#45 reissue token

### DIFF
--- a/src/api/api_utils.js
+++ b/src/api/api_utils.js
@@ -2,7 +2,6 @@
 import dayjs from 'dayjs';
 import { axiosInstance } from './axios';
 import { PATH_API } from './path';
-import { useUserAuthStore } from '../store';
 
 // utils
 
@@ -42,9 +41,7 @@ export const isValidToken = (accessToken) => {
 /**
  * refreshToken으로 토큰 재발급
  */
-const useTokenRefresh = async () => {
-  const { logout } = useUserAuthStore();
-
+const tokenRefresh = async () => {
   try {
     const response = await axiosInstance.post(PATH_API.REISSUE_TOKEN);
 
@@ -63,7 +60,6 @@ const useTokenRefresh = async () => {
     alert('로그인이 만료되었습니다.');
 
     localStorage.removeItem('accessToken');
-    logout();
 
     window.location.reload();
     return '';
@@ -89,7 +85,7 @@ export const tokenExpired = (exp) => {
   }
 
   expiredTimer = setTimeout(() => {
-    useTokenRefresh();
+    tokenRefresh();
   }, timeLeft);
 };
 

--- a/src/api/api_utils.js
+++ b/src/api/api_utils.js
@@ -35,7 +35,7 @@ export const isValidToken = (accessToken) => {
 
   const decoded = jwtDecode(accessToken);
 
-  return dayjs().isBefore(dayjs(decoded.exp));
+  return dayjs().isBefore(dayjs.unix(decoded.exp));
 };
 
 // ----------------------------------------------------------------------

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import { PATH_API } from './path';
+import { PATH } from '../route/path';
 
 const TIMEOUT_TIME = 10_000;
 
@@ -45,24 +46,36 @@ axiosInstance.interceptors.request.use(
 axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
-    // invalid token
-    // const originalRequest = error.config;
-    // /* eslint-disable no-underscore-dangle */
-    // if (error.response.status === 401 && !originalRequest._retry) {
-    //   originalRequest._retry = true;
+    // 액세스 토큰이 만료된 경우
+    const originalRequest = error.config;
 
-    //   // 리프레시 토큰도 만료된 경우 로그아웃 처리
-    //   alert('system.axios-401-error');
-    //   localStorage.removeItem('accessToken');
-    //   delete originalRequest.Authorization;
+    if (error.response.status === 403) {
+      // originalRequest._retry = true; // 무한 재요청 방지
 
-    //   // window.location.reload();
-    //   window.location.href = PATH.root;
-    //   // Promise.resolve('Error! failed token refresh');
-    //   // }
-    //   // }
-    // }
-    // /* eslint-enable no-underscore-dangle */
+      try {
+        const res = await axiosInstance.post(PATH_API.REISSUE_TOKEN);
+        const newAccessToken = res.data.accessToken;
+        // console.log(newAccessToken);
+        // console.log(isValidToken(newAccessToken));
+
+        localStorage.setItem('accessToken', newAccessToken);
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
+        // api 재요청
+        return axios(originalRequest);
+      } catch {
+        // TODO: 잘 되는지 확인 필요
+        // 리프레시 토큰도 만료된 경우 로그아웃 처리
+        localStorage.removeItem('accessToken');
+        delete originalRequest.headers.Authorization;
+
+        // window.location.reload();
+        window.location.href = PATH.root;
+        // Promise.resolve('Error! failed token refresh');
+        // }
+        // }
+      }
+    }
 
     // timeout
     if (axios.isCancel(error)) {

--- a/src/components/route/privateRoute.jsx
+++ b/src/components/route/privateRoute.jsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import { useUserAuthStore } from '../../store';
 import { PATH } from '../../route/path';
 
 export default function PrivateRoute() {
-  const { isLoggedIn } = useUserAuthStore();
+  const { isLoggedIn, logout } = useUserAuthStore();
+  const accessToken = localStorage.getItem('accessToken');
 
-  return isLoggedIn ? <Outlet /> : <Navigate to={PATH.root} />;
+  useEffect(() => {
+    if (!accessToken && isLoggedIn) {
+      console.log('액세스 토큰이 없어 로그아웃 처리');
+      logout();
+    }
+  });
+
+  return accessToken ? <Outlet /> : <Navigate to={PATH.root} />;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #45 액세스 토큰 갱신 api 연동

## 📝작업 내용

1. 로그아웃하지 않고 프론트 서버를 중단할 경우, 1시간 지난 후 재실행하면 만료된 토큰이 남아있어 원장/강사 페이지는 뜨지만 api 요청은 403 에러로 실패하게 됩니다. 
이런 경우를 대비하여 axios 응답 인터셉터에서도 (403 에러인 경우) 토큰 재발급 요청을 보내도록 했습니다. 
(기존에는 타이머를 지정하여 만료되기 직전에만 재발급 요청)

2. 또한 전역 상태 로그아웃 처리(useUserAuthStore의 logout())는 PrivateRoute에서만 처리해주도록 변경했습니다. 
(PrivateRoute가 렌더링될 때마다 토큰이 있는지 확인하여 토큰이 없으면 로그아웃.)
-> 이건 잘 동작하는지 추후 확인 필요,,

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
