### PR TITLE
#68 notice api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tanstack/react-query-devtools": "^5.54.1",
         "axios": "^1.7.5",
         "dayjs": "^1.11.12",
+        "file-saver": "^2.0.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.24.1",
@@ -3727,6 +3728,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/find-root": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query-devtools": "^5.54.1",
     "axios": "^1.7.5",
     "dayjs": "^1.11.12",
+    "file-saver": "^2.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.24.1",

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -19,7 +19,7 @@ export const PATH_API = {
 
   // 공지
   NOTICE_LIST: (lectureId, page, pageSize) => `/notice/list?lecture_id=${lectureId}&page=${page}&page_size=${pageSize}`,
-  NOTICE_CRUD: (noticeId) => `/notice/${noticeId}`,
+  NOTICE_RUD: (noticeId) => `/notice/${noticeId}`,
 
   // 원장
   // manage members

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -19,6 +19,7 @@ export const PATH_API = {
 
   // 공지
   NOTICE_LIST: (lectureId, page, pageSize) => `/notice/list?lecture_id=${lectureId}&page=${page}&page_size=${pageSize}`,
+  NOTICE_CRUD: (noticeId) => `/notice/${noticeId}`,
 
   // 원장
   // manage members

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -20,6 +20,7 @@ export const PATH_API = {
   // 공지
   NOTICE_LIST: (lectureId, page, pageSize) => `/notice/list?lecture_id=${lectureId}&page=${page}&page_size=${pageSize}`,
   NOTICE_RUD: (noticeId) => `/notice/${noticeId}`,
+  NOTICE_CREATE: '/notice/create',
 
   // 원장
   // manage members

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -2,7 +2,7 @@ import { SECRET } from '../config/secret';
 
 export const PATH_API = {
   API_DOMAIN: SECRET.server_ip,
-  
+
   // user
   SIGN_IN: '/user/login',
   FIND_ID: '/user/find-id',
@@ -16,6 +16,9 @@ export const PATH_API = {
   // register
   REGISTER_ACADEMY: '/registeration/request/academy',
   REGISTER_TEACHER: '/registeration/request/user',
+
+  // 공지
+  NOTICE_LIST: (lectureId, page, pageSize) => `/notice/list?lecture_id=${lectureId}&page=${page}&page_size=${pageSize}`,
 
   // 원장
   // manage members

--- a/src/api/queries/notice/useNoticeCRUD.js
+++ b/src/api/queries/notice/useNoticeCRUD.js
@@ -10,6 +10,7 @@ export const useNoticeDetail = (noticeId) =>
       const response = await axiosInstance.get(PATH_API.NOTICE_CRUD(noticeId));
       return response.data.data;
     },
+    refetchOnMount: true,
   });
 
 export const useNoticeDelete = () =>
@@ -18,4 +19,13 @@ export const useNoticeDelete = () =>
       const response = await axiosInstance.delete(PATH_API.NOTICE_CRUD(noticeId));
       return response.data.data;
     },
+  });
+
+export const useNoticeUpdate = () =>
+  useMutation({
+    mutationFn: async (payload) => {
+      const response = await axiosInstance.putForm(PATH_API.NOTICE_CRUD(payload.noticeId), payload.body, { headers: { 'Content-Type': 'multipart/form-data' } });
+      return response.data.data;
+    },
+    onError: (error) => console.log('updateError', error),
   });

--- a/src/api/queries/notice/useNoticeCRUD.js
+++ b/src/api/queries/notice/useNoticeCRUD.js
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '../../queryKeys';
 import { axiosInstance } from '../../axios';
 import { PATH_API } from '../../path';
@@ -8,6 +8,14 @@ export const useNoticeDetil = (noticeId) =>
     queryKey: [QUERY_KEY.NOTICECRUD(noticeId)],
     queryFn: async () => {
       const response = await axiosInstance.get(PATH_API.NOTICE_CRUD(noticeId));
+      return response.data.data;
+    },
+  });
+
+export const useNoticeDelete = () =>
+  useMutation({
+    mutationFn: async (noticeId) => {
+      const response = await axiosInstance.delete(PATH_API.NOTICE_CRUD(noticeId));
       return response.data.data;
     },
   });

--- a/src/api/queries/notice/useNoticeCRUD.js
+++ b/src/api/queries/notice/useNoticeCRUD.js
@@ -3,7 +3,7 @@ import { QUERY_KEY } from '../../queryKeys';
 import { axiosInstance } from '../../axios';
 import { PATH_API } from '../../path';
 
-export const useNoticeDetil = (noticeId) =>
+export const useNoticeDetail = (noticeId) =>
   useQuery({
     queryKey: [QUERY_KEY.NOTICECRUD(noticeId)],
     queryFn: async () => {

--- a/src/api/queries/notice/useNoticeCRUD.js
+++ b/src/api/queries/notice/useNoticeCRUD.js
@@ -29,3 +29,12 @@ export const useNoticeUpdate = () =>
     },
     onError: (error) => console.log('updateError', error),
   });
+
+export const useNoticeAdd = () =>
+  useMutation({
+    mutationFn: async (payload) => {
+      const response = await axiosInstance.postForm(PATH_API.NOTICE_CREATE, payload, { headers: { 'Content-Type': 'multipart/form-data' } });
+      return response.data.data;
+    },
+    onError: (error) => console.log('create Error', error),
+  });

--- a/src/api/queries/notice/useNoticeCRUD.js
+++ b/src/api/queries/notice/useNoticeCRUD.js
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '../../queryKeys';
+import { axiosInstance } from '../../axios';
+import { PATH_API } from '../../path';
+
+export const useNoticeDetil = (noticeId) =>
+  useQuery({
+    queryKey: [QUERY_KEY.NOTICECRUD(noticeId)],
+    queryFn: async () => {
+      const response = await axiosInstance.get(PATH_API.NOTICE_CRUD(noticeId));
+      return response.data.data;
+    },
+  });

--- a/src/api/queries/notice/useNoticeCRUD.js
+++ b/src/api/queries/notice/useNoticeCRUD.js
@@ -5,9 +5,9 @@ import { PATH_API } from '../../path';
 
 export const useNoticeDetail = (noticeId) =>
   useQuery({
-    queryKey: [QUERY_KEY.NOTICECRUD(noticeId)],
+    queryKey: [QUERY_KEY.NOTICERUD(noticeId)],
     queryFn: async () => {
-      const response = await axiosInstance.get(PATH_API.NOTICE_CRUD(noticeId));
+      const response = await axiosInstance.get(PATH_API.NOTICE_RUD(noticeId));
       return response.data.data;
     },
     refetchOnMount: true,
@@ -16,7 +16,7 @@ export const useNoticeDetail = (noticeId) =>
 export const useNoticeDelete = () =>
   useMutation({
     mutationFn: async (noticeId) => {
-      const response = await axiosInstance.delete(PATH_API.NOTICE_CRUD(noticeId));
+      const response = await axiosInstance.delete(PATH_API.NOTICE_RUD(noticeId));
       return response.data.data;
     },
   });
@@ -24,7 +24,7 @@ export const useNoticeDelete = () =>
 export const useNoticeUpdate = () =>
   useMutation({
     mutationFn: async (payload) => {
-      const response = await axiosInstance.putForm(PATH_API.NOTICE_CRUD(payload.noticeId), payload.body, { headers: { 'Content-Type': 'multipart/form-data' } });
+      const response = await axiosInstance.putForm(PATH_API.NOTICE_RUD(payload.noticeId), payload.body, { headers: { 'Content-Type': 'multipart/form-data' } });
       return response.data.data;
     },
     onError: (error) => console.log('updateError', error),

--- a/src/api/queries/notice/useNoticeList.js
+++ b/src/api/queries/notice/useNoticeList.js
@@ -11,4 +11,5 @@ export const useNoticeList = (lectureId, page, pageSize) =>
 
       return response.data.data;
     },
+    refetchOnMount: true,
   });

--- a/src/api/queries/notice/useNoticeList.js
+++ b/src/api/queries/notice/useNoticeList.js
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '../../queryKeys';
+import { axiosInstance } from '../../axios';
+import { PATH_API } from '../../path';
+
+export const useNoticeList = (lectureId, page, pageSize) =>
+  useQuery({
+    queryKey: [QUERY_KEY.NOTICELIST(lectureId, page, pageSize)],
+    queryFn: async () => {
+      const response = await axiosInstance.get(PATH_API.NOTICE_LIST(lectureId, page, pageSize));
+
+      return response.data.data;
+    },
+  });

--- a/src/api/queryKeys.js
+++ b/src/api/queryKeys.js
@@ -16,5 +16,8 @@ export const QUERY_KEY = {
   // manage lectures
   LECTURELIST: PATH_API.LECTURELIST,
   ATTENDEELIST: (lectureId) => PATH_API.ATTENDEELIST(lectureId),
+
+  // notice
+  NOTICELIST: (lectureId, page, pageSize) => PATH_API.NOTICE_LIST(lectureId, page, pageSize),
 };
 export default QUERY_KEY;

--- a/src/api/queryKeys.js
+++ b/src/api/queryKeys.js
@@ -19,6 +19,6 @@ export const QUERY_KEY = {
 
   // notice
   NOTICELIST: (lectureId, page, pageSize) => PATH_API.NOTICE_LIST(lectureId, page, pageSize),
-  NOTICECRUD: (noticeId) => PATH_API.NOTICE_CRUD(noticeId),
+  NOTICERUD: (noticeId) => PATH_API.NOTICE_RUD(noticeId),
 };
 export default QUERY_KEY;

--- a/src/api/queryKeys.js
+++ b/src/api/queryKeys.js
@@ -19,5 +19,6 @@ export const QUERY_KEY = {
 
   // notice
   NOTICELIST: (lectureId, page, pageSize) => PATH_API.NOTICE_LIST(lectureId, page, pageSize),
+  NOTICECRUD: (noticeId) => PATH_API.NOTICE_CRUD(noticeId),
 };
 export default QUERY_KEY;

--- a/src/components/notice/notice.jsx
+++ b/src/components/notice/notice.jsx
@@ -66,7 +66,7 @@ function Notice({
           </TableHead>
           <TableBody>
             {notices.map((notice) => (
-              <TableRow key={`${notice.title}_${notice.date}`}>
+              <TableRow key={`${notice.title}_${notice.created_at}`}>
                 <TableCell>
                   {role === 'teacher' && courseid !== undefined ? (
                     <Link to={`/${role}/class/${courseid}/notice/${notice.notice_id}`}>{notice.title}</Link>
@@ -74,7 +74,7 @@ function Notice({
                     <Link to={`/${role}/notice/${notice.notice_id}`}>{notice.title}</Link>
                   )}
                 </TableCell>
-                <TableCell align="right">{notice.date}</TableCell>
+                <TableCell align="right">{notice.created_at}</TableCell>
                 <TableCell align="right">{notice.views}</TableCell>
                 {!editable ? null : (
                   <TableCell align="right">

--- a/src/components/notice/notice.jsx
+++ b/src/components/notice/notice.jsx
@@ -35,7 +35,7 @@ function Notice({
 
   const handleClickUpdate = () => {
     handleClose();
-    navigate(`${updateURL}?id=${anchorEl?.value}`);
+    navigate(`${updateURL}?academy_id=${anchorEl?.value.split('&')[0]}&lecture_id=${anchorEl?.value.split('&')[1]}&notice_id=${anchorEl?.value.split('&')[2]}`);
   };
 
   const handleCloseDialog = () => {

--- a/src/components/notice/notice.jsx
+++ b/src/components/notice/notice.jsx
@@ -66,7 +66,7 @@ function Notice({
           </TableHead>
           <TableBody>
             {notices.map((notice) => (
-              <TableRow key={`${notice.title}_${notice.created_at}`}>
+              <TableRow key={`${notice.notice_id}`}>
                 <TableCell>
                   {role === 'teacher' && courseid !== undefined ? (
                     <Link to={`/${role}/class/${courseid}/notice/${notice.notice_id}`}>{notice.title}</Link>

--- a/src/components/notice/notice.jsx
+++ b/src/components/notice/notice.jsx
@@ -69,16 +69,16 @@ function Notice({
               <TableRow key={`${notice.title}_${notice.date}`}>
                 <TableCell>
                   {role === 'teacher' && courseid !== undefined ? (
-                    <Link to={`/${role}/class/${courseid}/notice/${notice.id}`}>{notice.title}</Link>
+                    <Link to={`/${role}/class/${courseid}/notice/${notice.notice_id}`}>{notice.title}</Link>
                   ) : (
-                    <Link to={`/${role}/notice/${notice.id}`}>{notice.title}</Link>
+                    <Link to={`/${role}/notice/${notice.notice_id}`}>{notice.title}</Link>
                   )}
                 </TableCell>
                 <TableCell align="right">{notice.date}</TableCell>
-                <TableCell align="right">{notice.view}</TableCell>
+                <TableCell align="right">{notice.views}</TableCell>
                 {!editable ? null : (
                   <TableCell align="right">
-                    <IconButton onClick={handleClickMore} value={notice.id}>
+                    <IconButton onClick={handleClickMore} value={notice.notice_id}>
                       <MoreVert />
                     </IconButton>
                   </TableCell>

--- a/src/pages/teacher/notice/addNotice.jsx
+++ b/src/pages/teacher/notice/addNotice.jsx
@@ -58,7 +58,6 @@ export default function TeacherAddNotice() {
     <>
       <TitleMedium title="공지사항 작성" />
       <Box component="form" onSubmit={handleSubmit}>
-        <VisuallyHiddenInput type="text" name="newid" defaultValue={state?.noticeId} />
         <Grid container spacing={2} sx={{ mx: 3, width: '60vw' }}>
           <Grid item xs={12}>
             <TextField name="title" label="제목" fullWidth />

--- a/src/pages/teacher/notice/courseNotice.jsx
+++ b/src/pages/teacher/notice/courseNotice.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { Pagination } from '@mui/material';
 import { AddButton, Notice, TitleMedium } from '../../../components';
 import { useUserAuthStore } from '../../../store';
 import { useNoticeList } from '../../../api/queries/notice/useNoticeList';
@@ -25,7 +26,8 @@ export default function CourseNotice() {
 
   const courseID = Number(params.courseid);
   const lecture = lectures.filter((n) => n.lecture_id === courseID)[0];
-  const { data: notices, refetch } = useNoticeList(courseID, 1, 10);
+  const [pageNo, setPage] = useState(1);
+  const { data: notices, refetch } = useNoticeList(courseID, pageNo, 10);
   const noticeDelete = useNoticeDelete();
 
   const handleClickAdd = () => {
@@ -36,10 +38,16 @@ export default function CourseNotice() {
     refetch();
   };
 
+  const handleChangePage = (event, value) => {
+    setPage(value);
+    refetch();
+  };
+
   return (
     <>
       <TitleMedium title={`${lecture.lecture_name} 공지사항`} />
       <Notice notices={notices !== undefined ? notices.notice_list : []} updateURL={`/teacher/class/${params.courseid}/notice/update`} handleClickDelete={handleClickDelete} />
+      <Pagination count={notices !== undefined ? Math.trunc(notices.notice_count / 10) + 1 : 1} sx={{ mt: 10 }} page={pageNo} onChange={handleChangePage} />
       <AddButton title="새 공지사항 등록" onClick={handleClickAdd} />
     </>
   );

--- a/src/pages/teacher/notice/courseNotice.jsx
+++ b/src/pages/teacher/notice/courseNotice.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { AddButton, Notice, TitleMedium } from '../../../components';
 import { useUserAuthStore } from '../../../store';
 import { useNoticeList } from '../../../api/queries/notice/useNoticeList';
+import { useNoticeDelete } from '../../../api/queries/notice/useNoticeCRUD';
 
 // test data
 // const courses = [
@@ -24,13 +25,15 @@ export default function CourseNotice() {
 
   const courseID = Number(params.courseid);
   const lecture = lectures.filter((n) => n.lecture_id === courseID)[0];
-  const { data: notices } = useNoticeList(courseID, 1, 10);
+  const { data: notices, refetch } = useNoticeList(courseID, 1, 10);
+  const noticeDelete = useNoticeDelete();
 
   const handleClickAdd = () => {
     navigate(`/teacher/class/${params.courseid}/notice/add`);
   };
   const handleClickDelete = (id) => {
-    console.log('delete', id);
+    noticeDelete.mutate(id);
+    refetch();
   };
 
   return (

--- a/src/pages/teacher/notice/courseNotice.jsx
+++ b/src/pages/teacher/notice/courseNotice.jsx
@@ -36,7 +36,7 @@ export default function CourseNotice() {
   return (
     <>
       <TitleMedium title={`${lecture.lecture_name} 공지사항`} />
-      <Notice notices={notices !== undefined ? notices : []} updateURL={`/teacher/class/${params.courseid}/notice/update`} handleClickDelete={handleClickDelete} />
+      <Notice notices={notices !== undefined ? notices.notice_list : []} updateURL={`/teacher/class/${params.courseid}/notice/update`} handleClickDelete={handleClickDelete} />
       <AddButton title="새 공지사항 등록" onClick={handleClickAdd} />
     </>
   );

--- a/src/pages/teacher/notice/courseNotice.jsx
+++ b/src/pages/teacher/notice/courseNotice.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AddButton, Notice, TitleMedium } from '../../../components';
 import { useUserAuthStore } from '../../../store';
+import { useNoticeList } from '../../../api/queries/notice/useNoticeList';
 
 // test data
 // const courses = [
@@ -10,11 +11,11 @@ import { useUserAuthStore } from '../../../store';
 //   { id: 3, name: '영어', students: 20 },
 //   { id: 4, name: '국어', students: 55 },
 // ];
-const notices = [
-  { id: 1, title: '공지사항 테스트3', date: '2024-07-20', view: 55 },
-  { id: 2, title: '7월 19일까지 과제', date: '2024-06-18', view: 101 },
-  { id: 2, title: '5월 21일 수업자료', date: '2024-05-21', view: 80 },
-];
+// const notices = [
+//   { id: 1, title: '공지사항 테스트3', date: '2024-07-20', view: 55 },
+//   { id: 2, title: '7월 19일까지 과제', date: '2024-06-18', view: 101 },
+//   { id: 2, title: '5월 21일 수업자료', date: '2024-05-21', view: 80 },
+// ];
 
 export default function CourseNotice() {
   const params = useParams();
@@ -23,6 +24,7 @@ export default function CourseNotice() {
 
   const courseID = Number(params.courseid);
   const lecture = lectures.filter((n) => n.lecture_id === courseID)[0];
+  const { data: notices } = useNoticeList(courseID, 1, 10);
 
   const handleClickAdd = () => {
     navigate(`/teacher/class/${params.courseid}/notice/add`);
@@ -34,7 +36,7 @@ export default function CourseNotice() {
   return (
     <>
       <TitleMedium title={`${lecture.lecture_name} 공지사항`} />
-      <Notice notices={notices} updateURL={`/teacher/class/${params.courseid}/notice/update`} handleClickDelete={handleClickDelete} />
+      <Notice notices={notices !== undefined ? notices : []} updateURL={`/teacher/class/${params.courseid}/notice/update`} handleClickDelete={handleClickDelete} />
       <AddButton title="새 공지사항 등록" onClick={handleClickAdd} />
     </>
   );

--- a/src/pages/teacher/notice/noticeDetails.jsx
+++ b/src/pages/teacher/notice/noticeDetails.jsx
@@ -31,13 +31,14 @@ export default function TeacherNoticeDetails() {
   const { courseid, id } = useParams();
   const navigate = useNavigate();
 
-  const { data: notice } = useNoticeDetail(id);
+  const { data: notice, isStale, refetch } = useNoticeDetail(id);
+  console.log(isStale);
 
   const handleClickList = () => {
     navigate(`/teacher/class/${courseid}/notice`);
   };
   const handleClickUpdate = () => {
-    navigate(`/teacher/class/${courseid}/notice/update?id=${id}`);
+    navigate(`/teacher/class/${courseid}/notice/update?academy_id=${id.split('&')[0]}&lecture_id=${id.split('&')[1]}&notice_id=${id.split('&')[2]}`);
   };
   const hadleFileDownload = (url, name) => {
     fetch(url, { method: 'get' })

--- a/src/pages/teacher/notice/noticeDetails.jsx
+++ b/src/pages/teacher/notice/noticeDetails.jsx
@@ -1,35 +1,37 @@
 import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Button, Box, Grid, Typography, Paper } from '@mui/material';
-import { BottomTwoButtons, TitleMedium } from '../../../components';
+import { Button, Box, Grid, Typography, Paper, Link } from '@mui/material';
+import { saveAs } from 'file-saver';
 
-const noticeList = [
-  {
-    id: 1,
-    title: '8월 정기고사 안내',
-    content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
-    date: '2024-07-20',
-    view: 55,
-  },
-  {
-    id: 2,
-    title: '7월 정기고사 안내',
-    content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
-    date: '2024-06-18',
-    view: 101,
-  },
-  { id: 3, title: '6월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-05-21', view: 129 },
-  { id: 4, title: '5월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-04-21', view: 129 },
-  { id: 5, title: '4월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-03-21', view: 129 },
-  { id: 6, title: '3월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-02-29', view: 201 },
-];
+import { BottomTwoButtons, TitleMedium } from '../../../components';
+import { useNoticeDetil } from '../../../api/queries/notice/useNoticeCRUD';
+
+// const noticeList = [
+//   {
+//     id: 1,
+//     title: '8월 정기고사 안내',
+//     content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
+//     date: '2024-07-20',
+//     view: 55,
+//   },
+//   {
+//     id: 2,
+//     title: '7월 정기고사 안내',
+//     content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
+//     date: '2024-06-18',
+//     view: 101,
+//   },
+//   { id: 3, title: '6월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-05-21', view: 129 },
+//   { id: 4, title: '5월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-04-21', view: 129 },
+//   { id: 5, title: '4월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-03-21', view: 129 },
+//   { id: 6, title: '3월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-02-29', view: 201 },
+// ];
 
 export default function TeacherNoticeDetails() {
   const { courseid, id } = useParams();
   const navigate = useNavigate();
 
-  const noticeID = Number(id);
-  const notice = noticeList.filter((n) => n.id === noticeID)[0];
+  const { data: notice } = useNoticeDetil(id);
 
   const handleClickList = () => {
     navigate(`/teacher/class/${courseid}/notice`);
@@ -37,30 +39,49 @@ export default function TeacherNoticeDetails() {
   const handleClickUpdate = () => {
     navigate(`/teacher/class/${courseid}/notice/update?id=${id}`);
   };
+  const hadleFileDownload = (url, name) => {
+    fetch(url, { method: 'get' })
+      .then((res) => res.blob())
+      .then((blob) => {
+        saveAs(blob, name);
+      });
+  };
 
   return (
     <>
       <TitleMedium title="공지사항 상세" />
       <Grid container spacing={2} sx={{ mt: 3, width: '60vw' }}>
         <Grid item xs={6}>
-          <Typography variant="body2">조회수: {notice.view}</Typography>
+          <Typography variant="body2">조회수: {notice?.notice.views}</Typography>
         </Grid>
         <Grid item xs={6}>
           <Typography variant="body2" align="right">
-            날짜: {notice.date}
+            날짜: {notice?.notice.updated_at.split('T')[0]}
           </Typography>
         </Grid>
         <Grid item xs={12}>
           <Paper variant="outlined" sx={{ minHeight: 50, padding: 2 }}>
-            <Typography>{notice.title}</Typography>
+            <Typography>{notice?.notice.title}</Typography>
           </Paper>
         </Grid>
         <Grid item xs={12}>
           <Paper variant="outlined" sx={{ height: 350, padding: 2, overflow: 'auto' }}>
-            <Typography>{notice.content}</Typography>
+            <Typography>{notice?.notice.content}</Typography>
+          </Paper>
+        </Grid>
+        <Grid item xs={12}>
+          {/* 첨부파일 */}
+          <Typography variant="h6">첨부파일</Typography>
+          <Paper variant="outlined" sx={{ height: 100, padding: 2, overflow: 'auto' }}>
+            {notice?.files.map((file) => (
+              <Button variant="text" size="small" onClick={() => hadleFileDownload(file.url, file.name)}>
+                {file.name}
+              </Button>
+            ))}
           </Paper>
         </Grid>
       </Grid>
+      {/* 이 부분은 전체공지 상세조회일 때 */}
       {courseid === undefined ? (
         <Box sx={{ position: 'fixed', bottom: '3vh', right: '3vw' }}>
           <Button

--- a/src/pages/teacher/notice/noticeDetails.jsx
+++ b/src/pages/teacher/notice/noticeDetails.jsx
@@ -4,7 +4,7 @@ import { Button, Box, Grid, Typography, Paper, Link } from '@mui/material';
 import { saveAs } from 'file-saver';
 
 import { BottomTwoButtons, TitleMedium } from '../../../components';
-import { useNoticeDetil } from '../../../api/queries/notice/useNoticeCRUD';
+import { useNoticeDetail } from '../../../api/queries/notice/useNoticeCRUD';
 
 // const noticeList = [
 //   {
@@ -31,7 +31,7 @@ export default function TeacherNoticeDetails() {
   const { courseid, id } = useParams();
   const navigate = useNavigate();
 
-  const { data: notice } = useNoticeDetil(id);
+  const { data: notice } = useNoticeDetail(id);
 
   const handleClickList = () => {
     navigate(`/teacher/class/${courseid}/notice`);

--- a/src/pages/teacher/notice/teacherNotice.jsx
+++ b/src/pages/teacher/notice/teacherNotice.jsx
@@ -3,24 +3,27 @@ import { useNavigate } from 'react-router-dom';
 
 import { useUserAuthStore } from '../../../store';
 import { TitleMedium, Notice } from '../../../components';
+import { useNoticeList } from '../../../api/queries/notice/useNoticeList';
 
-const notices = [
-  { id: 1, title: '8월 정기고사 안내', date: '2024-07-20', view: 55 },
-  { id: 2, title: '7월 정기고사 안내', date: '2024-06-18', view: 101 },
-  { id: 3, title: '6월 정기고사 안내', date: '2024-05-21', view: 129 },
-  { id: 4, title: '5월 정기고사 안내', date: '2024-04-21', view: 129 },
-  { id: 5, title: '4월 정기고사 안내', date: '2024-03-21', view: 129 },
-  { id: 6, title: '3월 정기고사 안내', date: '2024-02-29', view: 201 },
-];
+// const notices = [
+//   { id: 1, title: '8월 정기고사 안내', date: '2024-07-20', view: 55 },
+//   { id: 2, title: '7월 정기고사 안내', date: '2024-06-18', view: 101 },
+//   { id: 3, title: '6월 정기고사 안내', date: '2024-05-21', view: 129 },
+//   { id: 4, title: '5월 정기고사 안내', date: '2024-04-21', view: 129 },
+//   { id: 5, title: '4월 정기고사 안내', date: '2024-03-21', view: 129 },
+//   { id: 6, title: '3월 정기고사 안내', date: '2024-02-29', view: 201 },
+// ];
 
 export default function TeacherNotice() {
   const { user } = useUserAuthStore();
   const navigate = useNavigate();
 
+  const { data: notices } = useNoticeList(0, 1, 10);
+
   return (
     <>
       <TitleMedium title="전체 공지사항" />
-      <Notice notices={notices} editable={false} />
+      <Notice notices={notices !== undefined ? notices : []} editable={false} />
     </>
   );
 }

--- a/src/pages/teacher/notice/teacherNotice.jsx
+++ b/src/pages/teacher/notice/teacherNotice.jsx
@@ -23,7 +23,7 @@ export default function TeacherNotice() {
   return (
     <>
       <TitleMedium title="전체 공지사항" />
-      <Notice notices={notices !== undefined ? notices : []} editable={false} />
+      <Notice notices={notices !== undefined ? notices.notice_list : []} editable={false} />
     </>
   );
 }

--- a/src/pages/teacher/notice/teacherNotice.jsx
+++ b/src/pages/teacher/notice/teacherNotice.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Pagination } from '@mui/material';
 
 import { useUserAuthStore } from '../../../store';
 import { TitleMedium, Notice } from '../../../components';
@@ -18,12 +19,19 @@ export default function TeacherNotice() {
   const { user } = useUserAuthStore();
   const navigate = useNavigate();
 
-  const { data: notices } = useNoticeList(0, 1, 10);
+  const [pageNo, setPage] = useState(1);
+  const { data: notices, refetch } = useNoticeList(0, pageNo, 10);
+
+  const handleChangePage = (event, value) => {
+    setPage(value);
+    refetch();
+  };
 
   return (
     <>
       <TitleMedium title="전체 공지사항" />
       <Notice notices={notices !== undefined ? notices.notice_list : []} editable={false} />
+      <Pagination count={notices !== undefined ? notices.notice_count / 10 + 1 : 1} sx={{ mt: 10 }} page={pageNo} onChange={handleChangePage} />
     </>
   );
 }

--- a/src/pages/teacher/notice/teacherNotice.jsx
+++ b/src/pages/teacher/notice/teacherNotice.jsx
@@ -31,7 +31,7 @@ export default function TeacherNotice() {
     <>
       <TitleMedium title="전체 공지사항" />
       <Notice notices={notices !== undefined ? notices.notice_list : []} editable={false} />
-      <Pagination count={notices !== undefined ? notices.notice_count / 10 + 1 : 1} sx={{ mt: 10 }} page={pageNo} onChange={handleChangePage} />
+      <Pagination count={notices !== undefined ? Math.trunc(notices.notice_count / 10) + 1 : 1} sx={{ mt: 10 }} page={pageNo} onChange={handleChangePage} />
     </>
   );
 }

--- a/src/pages/teacher/notice/updateNotice.jsx
+++ b/src/pages/teacher/notice/updateNotice.jsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { Box, Button, Grid, styled, TextField } from '@mui/material';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { Box, Button, Container, Grid, styled, TextField } from '@mui/material';
 import { AttachFile } from '@mui/icons-material';
 
 import { SubmitButtons, TitleMedium } from '../../../components';
+import { useNoticeDetail, useNoticeUpdate } from '../../../api/queries/notice/useNoticeCRUD';
 
 // 테스트 데이터
 const oldTitle = '8월 정기고사 안내';
@@ -19,23 +20,67 @@ export default function TeacherUpdateNotice() {
   const { courseid } = useParams();
 
   // ? 뒤의 쿼리 파라미터 읽어오기.
-  const location = useLocation();
-  const queryParameter = new URLSearchParams(location.search);
-  const id = queryParameter.get('id');
+  const [queryParameter, setSearchParams] = useSearchParams();
+  const academyId = queryParameter.get('academy_id'); // 학원아이디
+  const lectureId = queryParameter.get('lecture_id'); // 강의아이디
+  const noticeId = queryParameter.get('notice_id'); // 공지아이디
+
+  const concatNoticeId = `${academyId}&${lectureId}&${noticeId}`;
+
+  // 아이디에 맞는 게시글 읽어오기
+  const { data: notice } = useNoticeDetail(concatNoticeId);
+  // 파일 수정하기
+  const noticeUpdate = useNoticeUpdate();
+
+  const [deleteFiles, setDeleteFiles] = useState([]); // 삭제한 파일 들
+  const [addFiles, setAddFiles] = useState([]); // 새로 추가한 파일
+  const [files, setFiles] = useState([]);
+
+  useEffect(() => {
+    if (notice) {
+      setFiles([...notice.files]);
+    }
+  }, [notice]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    const title = e.currentTarget.title.value;
-    const content = e.currentTarget.content.value;
+    const vtitle = e.currentTarget.title.value; // value Title
+    const vcontent = e.currentTarget.content.value; // value Content
 
-    if (title.length === 0) alert('제목을 입력해주세요');
-    else if (content.length === 0) alert('내용을 입력해주세요');
+    const fd = new FormData();
+    fd.append('title', vtitle);
+    fd.append('content', vcontent);
+    fd.append('files_deleted', deleteFiles.join(','));
+
+    addFiles.forEach((f) => fd.append('file', f));
+
+    if (vtitle.length === 0) alert('제목을 입력해주세요');
+    else if (vcontent.length === 0) alert('내용을 입력해주세요');
     else {
-      console.log(title);
-      console.log(content);
+      noticeUpdate.mutate(
+        { noticeId: concatNoticeId, body: fd },
+        {
+          onSuccess: () => {
+            navigate(`/teacher/class/${courseid}/notice`);
+          },
+        }
+      );
+    }
+  };
 
-      navigate(`/teacher/class/${courseid}/notice`);
+  const handleFileDelete = (name) => {
+    setDeleteFiles([...deleteFiles, name]);
+    setAddFiles(addFiles.filter((n) => n.name !== name));
+    setFiles(files.filter((n) => n.name !== name));
+  };
+
+  const handleFileAdd = (e) => {
+    for (let i = 0; i < e.target.files.length; i += 1) {
+      const tmpImage = e.target.files[i];
+
+      setAddFiles((prev) => [...prev, tmpImage]);
+      setFiles((prev) => [...prev, { name: tmpImage.name, url: '' }]);
     }
   };
 
@@ -45,16 +90,21 @@ export default function TeacherUpdateNotice() {
       <Box component="form" onSubmit={handleSubmit}>
         <Grid container spacing={2} sx={{ mt: 3, width: '60vw' }}>
           <Grid item xs={12}>
-            <TextField name="title" label="제목" fullWidth defaultValue={oldTitle} />
+            <TextField name="title" label="제목" fullWidth defaultValue={notice?.notice.title} />
           </Grid>
           <Grid item xs={12}>
-            <TextField name="content" label="내용" fullWidth multiline rows={14} defaultValue={oldContent} />
+            <TextField name="content" label="내용" fullWidth multiline rows={14} defaultValue={notice?.notice.content} />
           </Grid>
           <Grid item xs={12}>
             <Button component="label" role={undefined} tabIndex={-1} startIcon={<AttachFile />}>
               파일 첨부
-              <VisuallyHiddenInput type="file" accept="image/*" onChange={(e) => console.log(e.target.files)} multiple />
+              <VisuallyHiddenInput type="file" onChange={handleFileAdd} multiple />
             </Button>
+            {files.map((file) => (
+              <Container key={file.name}>
+                {file.name} <Button onClick={() => handleFileDelete(file.name)}>삭제</Button>
+              </Container>
+            ))}
           </Grid>
         </Grid>
         <SubmitButtons submitTitle="수정 완료" />

--- a/src/pages/teacher/teacherHome.jsx
+++ b/src/pages/teacher/teacherHome.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Title } from '../../components';
 import { useUserAuthStore } from '../../store';
 import { useLectures } from '../../api/queries/user/useLectures';
+import { useNoticeList } from '../../api/queries/notice/useNoticeList';
 
 // const lectures = [
 //   { name: '수학1', time: '14:00~16:00', students: 40 },
@@ -11,27 +12,28 @@ import { useLectures } from '../../api/queries/user/useLectures';
 //   { name: '미적분', time: '19:00~21:00', students: 33 },
 //  ];
 
-const noticeList = [
-  {
-    id: 1,
-    title: '8월 정기고사 안내',
-    content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
-    date: '2024-07-20',
-    view: 55,
-  },
-  {
-    id: 2,
-    title: '7월 정기고사 안내',
-    content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
-    date: '2024-06-18',
-    view: 101,
-  },
-];
+// const noticeList = [
+//   {
+//     id: 1,
+//     title: '8월 정기고사 안내',
+//     content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
+//     date: '2024-07-20',
+//     view: 55,
+//   },
+//   {
+//     id: 2,
+//     title: '7월 정기고사 안내',
+//     content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
+//     date: '2024-06-18',
+//     view: 101,
+//   },
+// ];
 
 export default function TeacherHome() {
   const { user, lectures } = useUserAuthStore();
   const navigate = useNavigate();
   const { refetch } = useLectures();
+  const { data: noticeList } = useNoticeList(0, 1, 5);
   if (lectures.length === 0) refetch();
   const handleLectureClick = (id) => {
     navigate(`/teacher/class/${id}`);
@@ -83,15 +85,15 @@ export default function TeacherHome() {
               <Typography variant="h5" fontWeight="bold">
                 학원 공지 사항
               </Typography>
-              {noticeList.map((notice) => (
-                <Box sx={{ width: '100%', bgcolor: '#ffffff', padding: '5px', marginY: '10px' }} onClick={() => handleNoticeClick(notice.id)}>
+              {noticeList?.notice_list.map((notice) => (
+                <Box sx={{ width: '100%', bgcolor: '#ffffff', padding: '5px', marginY: '10px' }} onClick={() => handleNoticeClick(notice.notice_id)}>
                   <Stack spacing={2}>
                     <Grid container justifyContent="space-between">
                       <Typography variant="subtitle1" fontWeight="bold">
                         {notice.title}
                       </Typography>
                       <Typography variant="subtitle1" fontWeight="bold">
-                        조회수 : {notice.view}
+                        조회수 : {notice.views}
                       </Typography>
                     </Grid>
                     <Typography variant="overline" sx={{ width: '100%', maxHeight: '100px', overflowY: 'hidden' }}>


### PR DESCRIPTION
## #️⃣연관된 이슈

#68 

## 📝작업 내용

학원 공지 조회, 강의별 공지조회/생성/삭제/수정 기능을 api 연동을 통해 구현하였습니다.
강의 생성시 서버에서 보내주는 notice_list[0]이 가장 최신의 공지로 보내주기 때문에 이 공지의 아이디를 addNotice.jsx로 넘겨서 다음 공지사항의 아이디를 추가할 수 있도록 하였습니다. 
파일 전송시 FormData()로 감싸서 axiosInstance.putForm() or postForm()으로 보내야한다는걸 깨달았습니다.
이거 해결하려고 친구랑 같이 3~4시간을 쏟은거 같네요..ㅋ..

### 스크린샷 (선택)
<img width="1664" alt="스크린샷 2024-11-18 오후 12 32 43" src="https://github.com/user-attachments/assets/1a62a1e5-e5d2-49bc-977a-dc5c28319d5d">


## 💬리뷰 요구사항(선택)
필요 없다 판단되는 코드들 알려주시면 삭제조치 하겠습니다. 