### PR TITLE
#76 exam crd

### DIFF
--- a/src/api/path.js
+++ b/src/api/path.js
@@ -49,6 +49,7 @@ export const PATH_API = {
   GET_LECTURES: (id) => `/lecture?user_id=${id}`,
   GETEXAMLIST: (lectureId) => `/lecture/${lectureId}/exam`, // 시험 리스트
   ADDEXAM: (lectureId) => `/lecture/${lectureId}/exam`,
+  DELETEEXAM: (lectureId, testId) => `/lecture/${lectureId}/exam/${testId}`,
 };
 
 export default PATH_API;

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -48,6 +48,7 @@ export const PATH_API = {
   // lectures
   GET_LECTURES: (id) => `/lecture?user_id=${id}`,
   GETEXAMLIST: (lectureId) => `/lecture/${lectureId}/exam`, // 시험 리스트
+  ADDEXAM: (lectureId) => `/lecture/${lectureId}/exam`,
 };
 
 export default PATH_API;

--- a/src/api/path.js
+++ b/src/api/path.js
@@ -47,6 +47,7 @@ export const PATH_API = {
   // 강사
   // lectures
   GET_LECTURES: (id) => `/lecture?user_id=${id}`,
+  GETEXAMLIST: (lectureId) => `/lecture/${lectureId}/exam`, // 시험 리스트
 };
 
 export default PATH_API;

--- a/src/api/queries/test/useAddExam.js
+++ b/src/api/queries/test/useAddExam.js
@@ -1,0 +1,12 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '../../queryKeys';
+import { axiosInstance } from '../../axios';
+import { PATH_API } from '../../path';
+
+export const useAddExam = (lectureId) =>
+  useMutation({
+    mutationFn: async (payload) => {
+      const response = await axiosInstance.post(PATH_API.ADDEXAM(lectureId), payload);
+      return response.data.data;
+    },
+  });

--- a/src/api/queries/test/useDeleteExam.js
+++ b/src/api/queries/test/useDeleteExam.js
@@ -1,0 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+import { Navigate } from 'react-router-dom';
+import { axiosInstance } from '../../axios';
+import { PATH_API } from '../../path';
+
+export const useDeleteExam = (lectureId, examId) =>
+  useMutation({
+    mutationFn: async () => {
+      const response = await axiosInstance.delete(PATH_API.DELETEEXAM(lectureId, examId));
+      return response.data.data;
+    },
+  });

--- a/src/api/queries/test/useGetExamList.js
+++ b/src/api/queries/test/useGetExamList.js
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { PATH_API } from '../../path';
+import { axiosInstance } from '../../axios';
+import { QUERY_KEY } from '../../queryKeys';
+
+export const useGetExamList = (lectureId) =>
+  useQuery({
+    queryKey: [QUERY_KEY.GETEXAMLIST(lectureId)],
+    queryFn: async () => {
+      const response = await axiosInstance.get(PATH_API.GETEXAMLIST(lectureId));
+      return response.data.data;
+    },
+    refetchOnMount: true,
+  });

--- a/src/api/queryKeys.js
+++ b/src/api/queryKeys.js
@@ -15,6 +15,7 @@ export const QUERY_KEY = {
 
   // examination (test)
   EXAM_CATEGORY: (academyId) => PATH_API.EXAM_CATEGORY(academyId),
+  GETEXAMLIST: (lectureId) => PATH_API.GETEXAMLIST(lectureId),
 
   // manage lectures
   LECTURELIST: PATH_API.LECTURELIST,

--- a/src/pages/teacher/test/addTest.jsx
+++ b/src/pages/teacher/test/addTest.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Box, Button, Chip, Container, Grid, Stack, TextField, Typography } from '@mui/material';
 
@@ -8,6 +9,8 @@ import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
 import dayjs from 'dayjs';
 
 import { SubmitButtons, Title } from '../../../components';
+import { useUserAuthStore } from '../../../store';
+import { useCategory } from '../../../api/queries/test/useCategory';
 
 const courses = [
   { id: 1, name: '미적분', students: 60 },
@@ -19,24 +22,36 @@ const courses = [
 export default function AddTest() {
   const { courseid } = useParams();
   const navigate = useNavigate();
+  const { user } = useUserAuthStore();
 
   const courseID = Number(courseid);
   const course = courses.filter((n) => n.id === courseID)[0];
 
-  const [category, setOriginCategory] = useState(['월말 정기 평가', '단원평가', '쪽지시험', '단어시험']);
-  const [selectCategory, setSelCategory] = useState('');
+  const addExam = useAddExam(lectureId);
+  const { data: categoryT } = useCategory(user.academy_id);
+  console.log('category', categoryT);
+
+  const [category, setOriginCategory] = useState([]);
+  const [selectCategory, setSelCategory] = useState([]);
   const [date, setDate] = useState();
 
-  const handleClickCategory = (e) => {
-    if (selectCategory === '') {
-      setSelCategory(e.currentTarget.innerText);
-      setOriginCategory(category.filter((n) => n !== e.currentTarget.innerText));
+  console.log('selectCategory', selectCategory);
+  useEffect(() => {
+    if (categoryT) {
+      setOriginCategory(categoryT);
+    }
+  }, [categoryT]);
+  const handleClickCategory = (cat) => {
+    console.log('cat', cat);
+    if (selectCategory.length === 0) {
+      setSelCategory([cat]);
+      setOriginCategory(category.filter((n) => n.exam_type_id !== cat.exam_type_id));
     } else {
       alert('시험 유형은 하나만 선택이 가능합니다.');
     }
   };
   const handleClickSelCategory = (e) => {
-    setOriginCategory([...category, selectCategory]);
+    setOriginCategory([...category, selectCategory[0]]);
     setSelCategory('');
   };
   const handleCreate = () => {
@@ -52,12 +67,12 @@ export default function AddTest() {
           <Typography variant="h6" align="center">
             시험 유형
           </Typography>
-          {selectCategory !== '' ? <Chip label={selectCategory} onClick={handleClickSelCategory} /> : null}
+          {selectCategory.length !== 0 ? <Chip label={selectCategory[0].exam_type_name} onClick={handleClickSelCategory} /> : null}
         </Grid>
         <Grid container sx={6} justifyContent="center">
           {category.map((cat) => (
             <Grid sx={4}>
-              <Chip label={cat} variant="outlined" sx={{ mx: 1 }} onClick={handleClickCategory} />
+              <Chip label={cat.exam_type_name} variant="outlined" sx={{ mx: 1 }} onClick={() => handleClickCategory(cat)} />
             </Grid>
           ))}
         </Grid>

--- a/src/pages/teacher/test/addTest.jsx
+++ b/src/pages/teacher/test/addTest.jsx
@@ -1,4 +1,3 @@
-import React, { useState } from 'react';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Box, Button, Chip, Container, Grid, Stack, TextField, Typography } from '@mui/material';
@@ -9,6 +8,7 @@ import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
 import dayjs from 'dayjs';
 
 import { SubmitButtons, Title } from '../../../components';
+import { useAddExam } from '../../../api/queries/test/useAddExam';
 import { useUserAuthStore } from '../../../store';
 import { useCategory } from '../../../api/queries/test/useCategory';
 
@@ -24,8 +24,8 @@ export default function AddTest() {
   const navigate = useNavigate();
   const { user } = useUserAuthStore();
 
-  const courseID = Number(courseid);
-  const course = courses.filter((n) => n.id === courseID)[0];
+  const lectureId = Number(courseid);
+  const course = courses.filter((n) => n.id === lectureId)[0];
 
   const addExam = useAddExam(lectureId);
   const { data: categoryT } = useCategory(user.academy_id);
@@ -54,14 +54,29 @@ export default function AddTest() {
     setOriginCategory([...category, selectCategory[0]]);
     setSelCategory('');
   };
-  const handleCreate = () => {
-    navigate(`/teacher/class/${course.id}/test`);
+  const handleCreate = (e) => {
+    e.preventDefault();
+
+    const name = e.currentTarget.testname.value;
+    // console.log(date.$y.$M.$D);
+    addExam.mutate(
+      {
+        exam_name: name,
+        exam_type_id: selectCategory[0].exam_type_id.toString(),
+        exam_date: `${date.$y}-${date.$M}-${date.$D}`,
+      },
+      {
+        onSuccess: () => {
+          navigate(`/teacher/class/${course.id}/test`);
+        },
+      }
+    );
   };
 
   return (
     <Container>
       <Title title={course.name} subtitle="시험만들기" />
-      <Stack component="form" spacing={2} useFlexGap sx={{ alignItems: 'center' }}>
+      <Stack component="form" spacing={2} useFlexGap sx={{ alignItems: 'center' }} onSubmit={handleCreate}>
         <TextField required name="testname" label="시험 이름" />
         <Grid sx={[12, { m: 1, p: 1 }]}>
           <Typography variant="h6" align="center">
@@ -84,7 +99,7 @@ export default function AddTest() {
           </LocalizationProvider>
         </Grid>
         <Box sx={{ position: 'fixed', bottom: '3vh', right: '3vw' }}>
-          <Button size="large" variant="contained" onClick={handleCreate}>
+          <Button type="submit" size="large" variant="contained">
             시험 생성 완료
           </Button>
         </Box>

--- a/src/pages/teacher/test/scoreList.jsx
+++ b/src/pages/teacher/test/scoreList.jsx
@@ -128,7 +128,7 @@ export default function ScoreList() {
             </Box>
           </Grid>
           <Box sx={{ position: 'fixed', bottom: '3vh', right: '3vw' }}>
-            <Button size="large" variant="contained" color="error" sx={{ mr: 2 }} onClick={handleDelete}>
+            <Button size="large" variant="outlined" color="error" sx={{ mr: 2 }} onClick={handleDelete}>
               삭제하기
             </Button>
             <Button

--- a/src/pages/teacher/test/scoreList.jsx
+++ b/src/pages/teacher/test/scoreList.jsx
@@ -4,6 +4,7 @@ import { Box, Button, Grid, IconButton, InputAdornment, TextField, Typography } 
 import SearchIcon from '@mui/icons-material/Search';
 import { Title } from '../../../components';
 import { useUserAuthStore } from '../../../store';
+import { useDeleteExam } from '../../../api/queries/test/useDeleteExam';
 
 // const courses = [
 //   { id: 1, name: '미적분', students: 60 },
@@ -22,11 +23,13 @@ const scores = [
 ];
 
 export default function ScoreList() {
-  const { courseid } = useParams();
+  const { courseid, testid } = useParams();
   const navigate = useNavigate();
   const { lectures } = useUserAuthStore();
 
   const [isEditing, setEditing] = useState([false, false, false, false, false, false]);
+
+  const deleteExam = useDeleteExam(courseid, testid);
 
   const handleEdit = (id) => {
     const editTmp = [...isEditing];
@@ -37,6 +40,10 @@ export default function ScoreList() {
       return null;
     });
     setEditing([...editTmp]);
+  };
+
+  const handleDelete = () => {
+    deleteExam.mutate({}, { onSuccess: () => navigate(`/teacher/class/${courseid}/test`) });
   };
 
   const courseID = Number(courseid);
@@ -121,6 +128,9 @@ export default function ScoreList() {
             </Box>
           </Grid>
           <Box sx={{ position: 'fixed', bottom: '3vh', right: '3vw' }}>
+            <Button size="large" variant="contained" color="error" sx={{ mr: 2 }} onClick={handleDelete}>
+              삭제하기
+            </Button>
             <Button
               size="large"
               variant="contained"

--- a/src/pages/teacher/test/testList.jsx
+++ b/src/pages/teacher/test/testList.jsx
@@ -112,7 +112,7 @@ export default function TestList() {
       <>
         <Title title={`${lecture.lecture_name}`} />
         <Typography align="left">수강생 {lecture.headcount}명</Typography>
-        <TableContainer component={Paper} sx={{ padding: 3 }}>
+        <TableContainer component={Paper} sx={{ padding: 3, maxHeight: '70vh', overflowY: 'auto' }}>
           <Container sx={{ display: 'flex' }}>
             <TextField label="Search" sx={{ mb: 1 }} />
             <IconButton onClick={handleFilterClick}>

--- a/src/pages/teacher/test/testList.jsx
+++ b/src/pages/teacher/test/testList.jsx
@@ -8,6 +8,7 @@ import { useCategory } from '../../../api/queries/test/useCategory';
 import { useUserAuthStore } from '../../../store';
 import { useAddCategory } from '../../../api/queries/test/useAddCategory';
 import { useDeleteCategory } from '../../../api/queries/test/useDeleteCategory';
+import { useGetExamList } from '../../../api/queries/test/useGetExamList';
 
 // const courses = [
 //   { id: 1, name: '미적분', students: 60 },
@@ -24,8 +25,11 @@ export default function TestList() {
   const addCategory = useAddCategory();
   const deleteCategory = useDeleteCategory();
 
-  const courseID = Number(courseid);
-  const lecture = lectures.filter((n) => n.lecture_id === courseID)[0];
+  const lectureId = Number(courseid);
+  const lecture = lectures.filter((n) => n.lecture_id === lectureId)[0];
+  const { data: exams } = useGetExamList(lectureId);
+  const examList = exams?.exams;
+  console.log(examList);
 
   const [category, setOriginCategory] = useState([]);
   const [unSelectCategory, setUnCategory] = useState(null); // 선택되지 않은 카테고리
@@ -43,10 +47,10 @@ export default function TestList() {
     }
   }, [categoryT, unSelectCategory]);
 
-  const tests = [
-    { id: 1, name: '쪽지시험 3차', all: 100, avg: 46.2, stdev: 55.3, category: '단원평가', students: '20/50' },
-    { id: 2, name: '6월말 정기평가', all: 100, avg: 60.2, stdev: 23.1, category: '중간고사', students: '50/50' },
-  ];
+  // const tests = [
+  //   { id: 1, name: '쪽지시험 3차', all: 100, avg: 46.2, stdev: 55.3, category: '단원평가', students: '20/50' },
+  //   { id: 2, name: '6월말 정기평가', all: 100, avg: 60.2, stdev: 23.1, category: '중간고사', students: '50/50' },
+  // ];
 
   const handleRowClick = (id) => {
     navigate(`/teacher/class/${lecture.lecture_id}/test/${id}`);
@@ -104,7 +108,6 @@ export default function TestList() {
   };
 
   if (categoryT) {
-    console.log(lecture);
     return (
       <>
         <Title title={`${lecture.lecture_name}`} />
@@ -157,26 +160,28 @@ export default function TestList() {
             <TableHead>
               <TableRow>
                 <TableCell>시험 이름</TableCell>
-                <TableCell>총점</TableCell>
+                <TableCell>최고점</TableCell>
                 <TableCell>평균</TableCell>
-                <TableCell>표준편차</TableCell>
+                <TableCell>최저점</TableCell>
                 <TableCell>시험유형</TableCell>
                 <TableCell>응시자수/전체인원</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {tests.map((test) => {
-                if ((selectCategory.length !== 0 && test.category === selectCategory[0].exam_type_name) || selectCategory.length === 0)
+              {examList?.map((exam) => {
+                if ((selectCategory.length !== 0 && exam.exam_type_id === selectCategory[0].exam_type_id) || selectCategory.length === 0)
                   return (
-                    <TableRow key={test.id} onClick={() => handleRowClick(test.id)}>
-                      <TableCell>{test.name}</TableCell>
-                      <TableCell>{test.all}</TableCell>
-                      <TableCell>{test.avg}</TableCell>
-                      <TableCell>{test.stdev}</TableCell>
+                    <TableRow key={exam.exam_id} onClick={() => handleRowClick(exam.exam_id)}>
+                      <TableCell>{exam.exam_name}</TableCell>
+                      <TableCell>{exam.high_score}</TableCell>
+                      <TableCell>{exam.average_score}</TableCell>
+                      <TableCell>{exam.low_score}</TableCell>
                       <TableCell>
-                        <Chip label={test.category} />
+                        <Chip label={category.filter((e) => e.exam_type_id === exam.exam_type_id)[0]?.exam_type_name} />
                       </TableCell>
-                      <TableCell>{test.students}</TableCell>
+                      <TableCell>
+                        {exam.headcount}/{lecture.headcount}
+                      </TableCell>
                     </TableRow>
                   );
                 return null;


### PR DESCRIPTION
## #️⃣연관된 이슈

#76 

## 📝작업 내용

시험의 생성, 조회, 삭제 api 연동작업 완료하였습니다.
시험리스트 테이블이 너무 길어진다면 테이블만 스크롤 되도록 maxHeight를 지정해두고 overflowY를 scroll로 설정하였습니다.
시험의 삭제버튼이 없어 시험 상세조회 페이지에서 하단에 삭제 버튼 추가하였습니다.

### 스크린샷 (선택)
<img width="1664" alt="스크린샷 2024-11-19 오후 5 41 46" src="https://github.com/user-attachments/assets/c68c69b2-2a8d-4c77-bb97-9a623d9ae502">
<img width="1664" alt="스크린샷 2024-11-19 오후 5 44 16" src="https://github.com/user-attachments/assets/7d5bb297-1c6f-490c-95de-5d90205e9d8e">

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
