### PR TITLE
#34 director notice

### DIFF
--- a/src/api/queries/notice/useNoticeCRUD.js
+++ b/src/api/queries/notice/useNoticeCRUD.js
@@ -19,6 +19,7 @@ export const useNoticeDelete = () =>
       const response = await axiosInstance.delete(PATH_API.NOTICE_RUD(noticeId));
       return response.data.data;
     },
+    onError: (error) => console.log('Error occurred at useNoticeDelete:', error),
   });
 
 export const useNoticeUpdate = () =>
@@ -27,7 +28,7 @@ export const useNoticeUpdate = () =>
       const response = await axiosInstance.putForm(PATH_API.NOTICE_RUD(payload.noticeId), payload.body, { headers: { 'Content-Type': 'multipart/form-data' } });
       return response.data.data;
     },
-    onError: (error) => console.log('updateError', error),
+    onError: (error) => console.log('Error occurred at useNoticeUpdate:', error),
   });
 
 export const useNoticeAdd = () =>
@@ -36,5 +37,5 @@ export const useNoticeAdd = () =>
       const response = await axiosInstance.postForm(PATH_API.NOTICE_CREATE, payload, { headers: { 'Content-Type': 'multipart/form-data' } });
       return response.data.data;
     },
-    onError: (error) => console.log('create Error', error),
+    onError: (error) => console.log('Error occurred at useNoticeAdd:', error),
   });

--- a/src/api/queries/notice/useNoticeList.js
+++ b/src/api/queries/notice/useNoticeList.js
@@ -3,12 +3,19 @@ import { QUERY_KEY } from '../../queryKeys';
 import { axiosInstance } from '../../axios';
 import { PATH_API } from '../../path';
 
+/**
+ * 학원 전체 또는 강의별 공지사항 목록 가져오는 useQuery
+ * @param {String} lectureId 강의 ID, 0이면 학원 전체공지
+ * @param {int} page
+ * @param {int} pageSize
+ *
+ */
 export const useNoticeList = (lectureId, page, pageSize) =>
   useQuery({
     queryKey: [QUERY_KEY.NOTICELIST(lectureId, page, pageSize)],
     queryFn: async () => {
       const response = await axiosInstance.get(PATH_API.NOTICE_LIST(lectureId, page, pageSize));
-
+      // console.log(response.data)
       return response.data.data;
     },
     refetchOnMount: true,

--- a/src/components/notice/notice.jsx
+++ b/src/components/notice/notice.jsx
@@ -35,7 +35,7 @@ function Notice({
 
   const handleClickUpdate = () => {
     handleClose();
-    navigate(`${updateURL}?academy_id=${anchorEl?.value.split('&')[0]}&lecture_id=${anchorEl?.value.split('&')[1]}&notice_id=${anchorEl?.value.split('&')[2]}`);
+    navigate(`${updateURL}/${anchorEl?.value}`);
   };
 
   const handleCloseDialog = () => {

--- a/src/pages/director/notice/addNotice.jsx
+++ b/src/pages/director/notice/addNotice.jsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { styled } from '@mui/material/styles';
 
-import { TextField, Box, Button, Grid } from '@mui/material';
+import { TextField, Box, Button, Grid, Container } from '@mui/material';
 import { AttachFile } from '@mui/icons-material';
 
 import { TitleMedium, SubmitButtons } from '../../../components';
+import { useNoticeAdd } from '../../../api/queries/notice/useNoticeCRUD';
 
 const VisuallyHiddenInput = styled('input')({
   display: 'none',
@@ -13,6 +14,25 @@ const VisuallyHiddenInput = styled('input')({
 
 export default function AddNotice() {
   const navigate = useNavigate();
+  const { state } = useLocation();
+
+  const [files, setFiles] = useState([]); // 첨부파일
+
+  const addNoticeMutation = useNoticeAdd();
+
+  const handleFileAdd = (e) => {
+    for (let i = 0; i < e.target.files.length; i += 1) {
+      const tmpImage = e.target.files[i];
+
+      setFiles((prev) => [...prev, tmpImage]);
+    }
+  };
+  const handleFileDelete = (file) => {
+    const currentIdx = files.indexOf(file);
+    const newFiles = [...files];
+    newFiles.splice(currentIdx, 1);
+    setFiles(newFiles);
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -25,10 +45,24 @@ export default function AddNotice() {
     } else if (content.length === 0) {
       alert('내용을 입력해주세요.');
     } else {
-      console.log(title);
-      console.log(content);
+      const splitNoticeId = state?.lastNoticeId.split('&');
+      const newNoticeId = `${splitNoticeId[0]}&${splitNoticeId[1]}&${Number(splitNoticeId[2]) + 1}`;
 
-      navigate('/director/notice');
+      const fd = new FormData();
+      fd.append('title', title);
+      fd.append('content', content);
+      fd.append('notice_id', newNoticeId);
+      files.forEach((f) => fd.append('file', f));
+
+      addNoticeMutation.mutate(fd, {
+        onSuccess: () => {
+          alert('공지 생성 성공!');
+          navigate('/director/notice');
+        },
+        onError: () => {
+          alert('공지 생성 실패!');
+        },
+      });
     }
   };
 
@@ -46,8 +80,13 @@ export default function AddNotice() {
           <Grid item xs={12}>
             <Button component="label" role={undefined} tabIndex={-1} startIcon={<AttachFile />}>
               파일 첨부
-              <VisuallyHiddenInput type="file" accept="image/*" onChange={(e) => console.log(e.target.files)} multiple />
+              <VisuallyHiddenInput type="file" onChange={handleFileAdd} multiple />
             </Button>
+            {files.map((file) => (
+              <Container key={file.name}>
+                {file.name} <Button onClick={() => handleFileDelete(file)}>삭제</Button>
+              </Container>
+            ))}
           </Grid>
         </Grid>
         <SubmitButtons submitTitle="등록하기" />

--- a/src/pages/director/notice/directorNotice.jsx
+++ b/src/pages/director/notice/directorNotice.jsx
@@ -6,6 +6,7 @@ import { Pagination } from '@mui/material';
 import { TitleMedium, Notice, AddButton } from '../../../components';
 import { useUserAuthStore } from '../../../store';
 import { useNoticeList } from '../../../api/queries/notice/useNoticeList';
+import { useNoticeDelete } from '../../../api/queries/notice/useNoticeCRUD';
 
 // const notices = {
 //   notice_count: 25,
@@ -27,10 +28,12 @@ const PAGE_SIZE = 6;
 export default function DirectorNotice() {
   const { user } = useUserAuthStore();
   const navigate = useNavigate();
+
   const [page, setPage] = useState(1);
   const [lastNoticeId, setLastNoticeId] = useState('');
 
   const { data: notices, refetch } = useNoticeList(0, page, PAGE_SIZE);
+  const deleteNoticeMutation = useNoticeDelete();
 
   useEffect(() => {
     if (notices) {
@@ -53,8 +56,14 @@ export default function DirectorNotice() {
   };
 
   const handleClickDelete = (id) => {
-    // TODO: 전체공지 삭제 api 연동
-    console.log('delete', id);
+    deleteNoticeMutation.mutate(id, {
+      onSuccess: () => {
+        alert('공지 삭제 성공!');
+      },
+      onError: () => {
+        alert('공지 삭제 실패!');
+      },
+    });
   };
 
   return (

--- a/src/pages/director/notice/directorNotice.jsx
+++ b/src/pages/director/notice/directorNotice.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Pagination } from '@mui/material';
@@ -28,8 +28,16 @@ export default function DirectorNotice() {
   const { user } = useUserAuthStore();
   const navigate = useNavigate();
   const [page, setPage] = useState(1);
+  const [lastNoticeId, setLastNoticeId] = useState('');
 
   const { data: notices, refetch } = useNoticeList(0, page, PAGE_SIZE);
+
+  useEffect(() => {
+    if (notices) {
+      // 공지가 없으면 academyId&0&0으로
+      setLastNoticeId(notices.notice_count !== 0 ? notices.notice_list[0].notice_id : `${user.academy_id}&0&0`);
+    }
+  }, [notices, user]);
 
   const handleChangePage = (e, value) => {
     setPage(value);
@@ -37,7 +45,11 @@ export default function DirectorNotice() {
   };
 
   const handleClickAdd = () => {
-    navigate('/director/notice/add');
+    navigate('/director/notice/add', {
+      state: {
+        lastNoticeId,
+      },
+    });
   };
 
   const handleClickDelete = (id) => {

--- a/src/pages/director/notice/directorNotice.jsx
+++ b/src/pages/director/notice/directorNotice.jsx
@@ -1,21 +1,40 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+import { Pagination } from '@mui/material';
 
 import { TitleMedium, Notice, AddButton } from '../../../components';
 import { useUserAuthStore } from '../../../store';
+import { useNoticeList } from '../../../api/queries/notice/useNoticeList';
 
-const notices = [
-  { id: 1, title: '8월 정기고사 안내', date: '2024-07-20', view: 55 },
-  { id: 2, title: '7월 정기고사 안내', date: '2024-06-18', view: 101 },
-  { id: 3, title: '6월 정기고사 안내', date: '2024-05-21', view: 129 },
-  { id: 4, title: '5월 정기고사 안내', date: '2024-04-21', view: 129 },
-  { id: 5, title: '4월 정기고사 안내', date: '2024-03-21', view: 129 },
-  { id: 6, title: '3월 정기고사 안내', date: '2024-02-29', view: 201 },
-];
+// const notices = {
+//   notice_count: 25,
+//   notice_list: [
+//     {
+//       title: '코로나19로 인한 학원 운영 방침',
+//       content: '코로나19 예방 방침 공지합니다.',
+//       user_id: 'test_chief',
+//       views: 123,
+//       notice_id: 'test_academy&0&5',
+//       created_at: '2024-11-16',
+//       updated_at: '2024-11-17',
+//     },
+//   ],
+// };
+
+const PAGE_SIZE = 6;
 
 export default function DirectorNotice() {
   const { user } = useUserAuthStore();
   const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+
+  const { data: notices, refetch } = useNoticeList(0, page, PAGE_SIZE);
+
+  const handleChangePage = (e, value) => {
+    setPage(value);
+    refetch();
+  };
 
   const handleClickAdd = () => {
     navigate('/director/notice/add');
@@ -29,8 +48,8 @@ export default function DirectorNotice() {
   return (
     <>
       <TitleMedium title="전체 공지사항" />
-      {/* TODO: editable 주석 제거 */}
-      <Notice notices={notices} /* editable={user.role === 'CHIEF'} */ updateURL="/director/notice/update" handleClickDelete={handleClickDelete} />
+      <Notice notices={notices ? notices.notice_list : []} editable={user.role === 'CHIEF'} updateURL="/director/notice/update" handleClickDelete={handleClickDelete} />
+      <Pagination count={notices ? Math.trunc(notices.notice_count / PAGE_SIZE) + 1 : 1} page={page} onChange={handleChangePage} sx={{ position: 'fixed', bottom: 30 }} />
       <AddButton title="새 공지사항 등록" onClick={handleClickAdd} />
     </>
   );

--- a/src/pages/director/notice/noticeDetails.jsx
+++ b/src/pages/director/notice/noticeDetails.jsx
@@ -57,7 +57,7 @@ export default function NoticeDetails() {
         </Grid>
         <Grid item xs={6}>
           <Typography variant="body2" align="right">
-            날짜: {data?.notice.created_at}
+            날짜: {data?.notice.created_at.split('T')[0]}
           </Typography>
         </Grid>
         <Grid item xs={12}>

--- a/src/pages/director/notice/noticeDetails.jsx
+++ b/src/pages/director/notice/noticeDetails.jsx
@@ -1,37 +1,38 @@
 import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { saveAs } from 'file-saver';
 
-import { Grid, Paper, Typography } from '@mui/material';
+import { Grid, Paper, Typography, Button } from '@mui/material';
 
 import { TitleMedium, BottomTwoButtons } from '../../../components';
+import { useNoticeDetail } from '../../../api/queries/notice/useNoticeCRUD';
 
-const noticeList = [
-  {
-    id: 1,
-    title: '8월 정기고사 안내',
-    content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
-    date: '2024-07-20',
-    view: 55,
-  },
-  {
-    id: 2,
-    title: '7월 정기고사 안내',
-    content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
-    date: '2024-06-18',
-    view: 101,
-  },
-  { id: 3, title: '6월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-05-21', view: 129 },
-  { id: 4, title: '5월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-04-21', view: 129 },
-  { id: 5, title: '4월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-03-21', view: 129 },
-  { id: 6, title: '3월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-02-29', view: 201 },
-];
+// const data = {
+//   notice: {
+//     notice_id: 'test_academy2&0&5',
+//     notice_num: 5,
+//     lecture_id: 0,
+//     title: '코로나19로 인한 학원 운영 방침',
+//     content: '코로나19로 인한 운영 방침 안내',
+//     user_id: 'test_chief',
+//     views: 0,
+//     created_at: '2021-08-30',
+//     updated_at: '2021-08-30',
+//   },
+//   files: [
+//     {
+//       url: 'String',
+//       name: '코로나.jpg',
+//     },
+//   ],
+// };
 
 export default function NoticeDetails() {
   const params = useParams();
   const navigate = useNavigate();
 
-  const noticeId = Number(params.id);
-  const notice = noticeList.filter((n) => n.id === noticeId)[0];
+  const noticeId = params.id;
+  const { data } = useNoticeDetail(noticeId);
 
   const handleClickBefore = () => {
     navigate('/director/notice');
@@ -39,27 +40,44 @@ export default function NoticeDetails() {
   const handleClickUpdate = () => {
     navigate('/director/notice/update');
   };
+  const hadleFileDownload = (url, name) => {
+    fetch(url, { method: 'get' })
+      .then((res) => res.blob())
+      .then((blob) => {
+        saveAs(blob, name);
+      });
+  };
 
   return (
     <>
       <TitleMedium title="공지사항 상세" />
       <Grid container spacing={2} sx={{ mt: 3, width: '60vw' }}>
         <Grid item xs={6}>
-          <Typography variant="body2">조회수: {notice.view}</Typography>
+          <Typography variant="body2">조회수: {data?.notice.views}</Typography>
         </Grid>
         <Grid item xs={6}>
           <Typography variant="body2" align="right">
-            날짜: {notice.date}
+            날짜: {data?.notice.created_at}
           </Typography>
         </Grid>
         <Grid item xs={12}>
           <Paper variant="outlined" sx={{ minHeight: 50, padding: 2 }}>
-            <Typography>{notice.title}</Typography>
+            <Typography>{data?.notice.title}</Typography>
           </Paper>
         </Grid>
         <Grid item xs={12}>
           <Paper variant="outlined" sx={{ height: 350, padding: 2, overflow: 'auto' }}>
-            <Typography>{notice.content}</Typography>
+            <Typography>{data?.notice.content}</Typography>
+          </Paper>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography>첨부파일</Typography>
+          <Paper variant="outlined" sx={{ height: 100, padding: 2, overflow: 'auto' }}>
+            {data?.files.map((file) => (
+              <Button variant="text" size="small" onClick={() => hadleFileDownload(file.url, file.name)}>
+                {file.name}
+              </Button>
+            ))}
           </Paper>
         </Grid>
       </Grid>

--- a/src/pages/director/notice/noticeDetails.jsx
+++ b/src/pages/director/notice/noticeDetails.jsx
@@ -38,7 +38,7 @@ export default function NoticeDetails() {
     navigate('/director/notice');
   };
   const handleClickUpdate = () => {
-    navigate('/director/notice/update');
+    navigate(`/director/notice/update/${noticeId}`);
   };
   const hadleFileDownload = (url, name) => {
     fetch(url, { method: 'get' })

--- a/src/pages/director/notice/updateNotice.jsx
+++ b/src/pages/director/notice/updateNotice.jsx
@@ -1,14 +1,12 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { styled } from '@mui/material/styles';
 
-import { TextField, Box, Grid, Button } from '@mui/material';
+import { TextField, Box, Grid, Button, Container } from '@mui/material';
 import { AttachFile } from '@mui/icons-material';
 
 import { TitleMedium, SubmitButtons } from '../../../components';
-
-const oldTitle = '8월 정기고사 안내';
-const oldContent = '안녕하세요. \n1학기 마지막 정기고사 안내입니다. \n...';
+import { useNoticeDetail, useNoticeUpdate } from '../../../api/queries/notice/useNoticeCRUD';
 
 const VisuallyHiddenInput = styled('input')({
   display: 'none',
@@ -16,6 +14,35 @@ const VisuallyHiddenInput = styled('input')({
 
 export default function UpdateNotice() {
   const navigate = useNavigate();
+  const { id: noticeId } = useParams();
+
+  const [files, setFiles] = useState([]); // 첨부 파일들
+  const [deleteFiles, setDeleteFiles] = useState([]); // 삭제한 파일들 (파일명)
+  const [addFiles, setAddFiles] = useState([]); // 새로 추가한 파일들
+
+  const { data: noticeData } = useNoticeDetail(noticeId);
+  const updateNoticeMutation = useNoticeUpdate();
+
+  useEffect(() => {
+    // 기존 첨부파일
+    if (noticeData) {
+      setFiles(noticeData.files);
+    }
+  }, [noticeData]);
+
+  const handleFileAdd = (e) => {
+    for (let i = 0; i < e.target.files.length; i += 1) {
+      const tmpImage = e.target.files[i];
+
+      setFiles((prev) => [...prev, tmpImage]);
+      setAddFiles((prev) => [...prev, tmpImage]);
+    }
+  };
+  const handleFileDelete = (name) => {
+    setDeleteFiles([...deleteFiles, name]);
+    setAddFiles(addFiles.filter((n) => n.name !== name));
+    setFiles(files.filter((n) => n.name !== name));
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -28,10 +55,27 @@ export default function UpdateNotice() {
     } else if (newContent.length === 0) {
       alert('내용을 입력해주세요.');
     } else {
-      console.log(newTitle);
-      console.log(newContent);
+      const fd = new FormData();
+      fd.append('title', newTitle);
+      fd.append('content', newContent);
+      fd.append('files_deleted', deleteFiles.join(','));
+      addFiles.forEach((f) => fd.append('file', f));
 
-      navigate('/director/notice');
+      updateNoticeMutation.mutate(
+        {
+          noticeId,
+          body: fd,
+        },
+        {
+          onSuccess: () => {
+            alert('공지 수정 성공!');
+            navigate('/director/notice');
+          },
+          onError: () => {
+            alert('공지 수정 실패!');
+          },
+        }
+      );
     }
   };
 
@@ -41,16 +85,21 @@ export default function UpdateNotice() {
       <Box component="form" onSubmit={handleSubmit}>
         <Grid container spacing={2} sx={{ mt: 3, width: '60vw' }}>
           <Grid item xs={12}>
-            <TextField name="title" label="제목" fullWidth defaultValue={oldTitle} />
+            <TextField name="title" label="제목" fullWidth defaultValue={noticeData?.notice.title} />
           </Grid>
           <Grid item xs={12}>
-            <TextField name="content" label="내용" fullWidth multiline rows={14} defaultValue={oldContent} />
+            <TextField name="content" label="내용" fullWidth multiline rows={14} defaultValue={noticeData?.notice.content} />
           </Grid>
           <Grid item xs={12}>
             <Button component="label" role={undefined} tabIndex={-1} startIcon={<AttachFile />}>
               파일 첨부
-              <VisuallyHiddenInput type="file" accept="image/*" onChange={(e) => console.log(e.target.files)} multiple />
+              <VisuallyHiddenInput type="file" onChange={handleFileAdd} multiple />
             </Button>
+            {files.map((file) => (
+              <Container key={file.name}>
+                {file.name} <Button onClick={() => handleFileDelete(file.name)}>삭제</Button>
+              </Container>
+            ))}
           </Grid>
         </Grid>
         <SubmitButtons submitTitle="수정 완료" />

--- a/src/pages/director/notice/updateNotice.jsx
+++ b/src/pages/director/notice/updateNotice.jsx
@@ -16,6 +16,8 @@ export default function UpdateNotice() {
   const navigate = useNavigate();
   const { id: noticeId } = useParams();
 
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
   const [files, setFiles] = useState([]); // 첨부 파일들
   const [deleteFiles, setDeleteFiles] = useState([]); // 삭제한 파일들 (파일명)
   const [addFiles, setAddFiles] = useState([]); // 새로 추가한 파일들
@@ -24,8 +26,10 @@ export default function UpdateNotice() {
   const updateNoticeMutation = useNoticeUpdate();
 
   useEffect(() => {
-    // 기존 첨부파일
+    // 기존 공지사항 내용 띄우기
     if (noticeData) {
+      setTitle(noticeData.notice.title);
+      setContent(noticeData.notice.content);
       setFiles(noticeData.files);
     }
   }, [noticeData]);
@@ -47,17 +51,14 @@ export default function UpdateNotice() {
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    const newTitle = e.currentTarget.title.value;
-    const newContent = e.currentTarget.content.value;
-
-    if (newTitle.length === 0) {
+    if (title.length === 0) {
       alert('제목을 입력해주세요.');
-    } else if (newContent.length === 0) {
+    } else if (content.length === 0) {
       alert('내용을 입력해주세요.');
     } else {
       const fd = new FormData();
-      fd.append('title', newTitle);
-      fd.append('content', newContent);
+      fd.append('title', title);
+      fd.append('content', content);
       fd.append('files_deleted', deleteFiles.join(','));
       addFiles.forEach((f) => fd.append('file', f));
 
@@ -85,10 +86,10 @@ export default function UpdateNotice() {
       <Box component="form" onSubmit={handleSubmit}>
         <Grid container spacing={2} sx={{ mt: 3, width: '60vw' }}>
           <Grid item xs={12}>
-            <TextField name="title" label="제목" fullWidth defaultValue={noticeData?.notice.title} />
+            <TextField label="제목" value={title} onChange={(e) => setTitle(e.target.value)} fullWidth />
           </Grid>
           <Grid item xs={12}>
-            <TextField name="content" label="내용" fullWidth multiline rows={14} defaultValue={noticeData?.notice.content} />
+            <TextField label="내용" value={content} onChange={(e) => setContent(e.target.value)} fullWidth multiline rows={14} />
           </Grid>
           <Grid item xs={12}>
             <Button component="label" role={undefined} tabIndex={-1} startIcon={<AttachFile />}>

--- a/src/pages/teacher/notice/noticeDetails.jsx
+++ b/src/pages/teacher/notice/noticeDetails.jsx
@@ -6,39 +6,18 @@ import { saveAs } from 'file-saver';
 import { BottomTwoButtons, TitleMedium } from '../../../components';
 import { useNoticeDetail } from '../../../api/queries/notice/useNoticeCRUD';
 
-// const noticeList = [
-//   {
-//     id: 1,
-//     title: '8월 정기고사 안내',
-//     content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
-//     date: '2024-07-20',
-//     view: 55,
-//   },
-//   {
-//     id: 2,
-//     title: '7월 정기고사 안내',
-//     content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...',
-//     date: '2024-06-18',
-//     view: 101,
-//   },
-//   { id: 3, title: '6월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-05-21', view: 129 },
-//   { id: 4, title: '5월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-04-21', view: 129 },
-//   { id: 5, title: '4월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-03-21', view: 129 },
-//   { id: 6, title: '3월 정기고사 안내', content: '안녕하세요. \n이번달 정기고사 안내드립니다. \n...', date: '2024-02-29', view: 201 },
-// ];
-
 export default function TeacherNoticeDetails() {
-  const { courseid, id } = useParams();
+  const { courseid, id: noticeId } = useParams();
   const navigate = useNavigate();
 
-  const { data: notice, isStale, refetch } = useNoticeDetail(id);
+  const { data: notice, isStale, refetch } = useNoticeDetail(noticeId);
   console.log(isStale);
 
   const handleClickList = () => {
     navigate(`/teacher/class/${courseid}/notice`);
   };
   const handleClickUpdate = () => {
-    navigate(`/teacher/class/${courseid}/notice/update?academy_id=${id.split('&')[0]}&lecture_id=${id.split('&')[1]}&notice_id=${id.split('&')[2]}`);
+    navigate(`/teacher/class/${courseid}/notice/update/${noticeId}`);
   };
   const hadleFileDownload = (url, name) => {
     fetch(url, { method: 'get' })

--- a/src/pages/teacher/notice/updateNotice.jsx
+++ b/src/pages/teacher/notice/updateNotice.jsx
@@ -1,15 +1,11 @@
 import React, { useEffect, useState } from 'react';
 
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Box, Button, Container, Grid, styled, TextField } from '@mui/material';
 import { AttachFile } from '@mui/icons-material';
 
 import { SubmitButtons, TitleMedium } from '../../../components';
 import { useNoticeDetail, useNoticeUpdate } from '../../../api/queries/notice/useNoticeCRUD';
-
-// 테스트 데이터
-const oldTitle = '8월 정기고사 안내';
-const oldContent = '안녕하세요. \n1학기 마지막 정기고사 안내입니다. \n...';
 
 const VisuallyHiddenInput = styled('input')({
   display: 'none',
@@ -17,18 +13,10 @@ const VisuallyHiddenInput = styled('input')({
 
 export default function TeacherUpdateNotice() {
   const navigate = useNavigate();
-  const { courseid } = useParams();
-
-  // ? 뒤의 쿼리 파라미터 읽어오기.
-  const [queryParameter, setSearchParams] = useSearchParams();
-  const academyId = queryParameter.get('academy_id'); // 학원아이디
-  const lectureId = queryParameter.get('lecture_id'); // 강의아이디
-  const noticeId = queryParameter.get('notice_id'); // 공지아이디
-
-  const concatNoticeId = `${academyId}&${lectureId}&${noticeId}`;
+  const { courseid, id: noticeId } = useParams();
 
   // 아이디에 맞는 게시글 읽어오기
-  const { data: notice } = useNoticeDetail(concatNoticeId);
+  const { data: notice } = useNoticeDetail(noticeId);
   // 파일 수정하기
   const noticeUpdate = useNoticeUpdate();
 
@@ -59,7 +47,7 @@ export default function TeacherUpdateNotice() {
     else if (vcontent.length === 0) alert('내용을 입력해주세요');
     else {
       noticeUpdate.mutate(
-        { noticeId: concatNoticeId, body: fd },
+        { noticeId, body: fd },
         {
           onSuccess: () => {
             navigate(`/teacher/class/${courseid}/notice`);

--- a/src/pages/teacher/notice/updateNotice.jsx
+++ b/src/pages/teacher/notice/updateNotice.jsx
@@ -20,12 +20,16 @@ export default function TeacherUpdateNotice() {
   // 파일 수정하기
   const noticeUpdate = useNoticeUpdate();
 
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
   const [deleteFiles, setDeleteFiles] = useState([]); // 삭제한 파일 들
   const [addFiles, setAddFiles] = useState([]); // 새로 추가한 파일
   const [files, setFiles] = useState([]);
 
   useEffect(() => {
     if (notice) {
+      setTitle(notice.notice.title);
+      setContent(notice.notice.content);
       setFiles([...notice.files]);
     }
   }, [notice]);
@@ -33,18 +37,15 @@ export default function TeacherUpdateNotice() {
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    const vtitle = e.currentTarget.title.value; // value Title
-    const vcontent = e.currentTarget.content.value; // value Content
-
     const fd = new FormData();
-    fd.append('title', vtitle);
-    fd.append('content', vcontent);
+    fd.append('title', title);
+    fd.append('content', content);
     fd.append('files_deleted', deleteFiles.join(','));
 
     addFiles.forEach((f) => fd.append('file', f));
 
-    if (vtitle.length === 0) alert('제목을 입력해주세요');
-    else if (vcontent.length === 0) alert('내용을 입력해주세요');
+    if (title.length === 0) alert('제목을 입력해주세요');
+    else if (content.length === 0) alert('내용을 입력해주세요');
     else {
       noticeUpdate.mutate(
         { noticeId, body: fd },
@@ -78,10 +79,10 @@ export default function TeacherUpdateNotice() {
       <Box component="form" onSubmit={handleSubmit}>
         <Grid container spacing={2} sx={{ mt: 3, width: '60vw' }}>
           <Grid item xs={12}>
-            <TextField name="title" label="제목" fullWidth defaultValue={notice?.notice.title} />
+            <TextField label="제목" value={title} onChange={(e) => setTitle(e.target.value)} fullWidth />
           </Grid>
           <Grid item xs={12}>
-            <TextField name="content" label="내용" fullWidth multiline rows={14} defaultValue={notice?.notice.content} />
+            <TextField label="내용" value={content} onChange={(e) => setContent(e.target.value)} fullWidth multiline rows={14} />
           </Grid>
           <Grid item xs={12}>
             <Button component="label" role={undefined} tabIndex={-1} startIcon={<AttachFile />}>

--- a/src/route/path.js
+++ b/src/route/path.js
@@ -22,7 +22,7 @@ export const PATH = {
         LECTURENOTICE: {
           ROOT: 'notice', // 각 강의별 공지사항
           ADD: 'add',
-          UPDATE: 'update',
+          UPDATE: 'update/:id',
           DETAIL: ':id',
         },
         TEST: {

--- a/src/route/path.js
+++ b/src/route/path.js
@@ -74,7 +74,7 @@ export const PATH = {
     NOTICE: {
       ROOT: 'notice',
       ADD: 'add',
-      UPDATE: 'update',
+      UPDATE: 'update/:id',
       DETAILS: ':id',
     },
   },


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34 원장 전체공지 메뉴 API 연동

## 📝작업 내용

> 원장 전체공지 메뉴 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 공지수정 경로 "~/update/:id"로 변경했습니다.
또 공지 수정 시 제목과 내용이 defaultValue와 uncontrolled 방식으로 관리할 경우 아래처럼 리렌더링 시 업데이트가 제대로 안되어 state를 사용한 controlled 방식으로 관리하도록 수정하였습니다.
![스크린샷 2024-11-20 오후 1 12 22](https://github.com/user-attachments/assets/c02a6049-6394-49af-b195-00e0fc4b1dc6)

