### PR TITLE
feat: 성적 조회, 수정, 추가 api 연동 #75

### DIFF
--- a/src/api/path.js
+++ b/src/api/path.js
@@ -35,6 +35,7 @@ export const PATH_API = {
   EXAM_CATEGORY: (academyId) => `/exam-type/academy/${academyId}`,
   ADD_CATEGORY: '/exam-type',
   DELETE_CATEGORY: (examTypeId) => `/exam-type/${examTypeId}`,
+  SCORES: (lectureId, examId) => `/lecture/${lectureId}/exam/${examId}/score`,
 
   // manage lectures
   LECTURELIST: '/lecture',

--- a/src/api/queries/test/useScore.js
+++ b/src/api/queries/test/useScore.js
@@ -1,0 +1,30 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '../../queryKeys';
+import { axiosInstance } from '../../axios';
+import { PATH_API } from '../../path';
+
+export const useScoreList = (lectureId, examId) =>
+  useQuery({
+    queryKey: [QUERY_KEY.SCORELIST(lectureId, examId)],
+    queryFn: async () => {
+      const response = await axiosInstance.get(PATH_API.SCORES(lectureId, examId));
+      return response.data.data;
+    },
+    refetchOnMount: true,
+  });
+
+export const useScoreEdit = (lectureId, examId) =>
+  useMutation({
+    mutationFn: async (payload) => {
+      const response = await axiosInstance.put(PATH_API.SCORES(lectureId, examId), payload);
+      return response.data.data;
+    },
+  });
+
+export const useScoreAdd = (lectureId, examId) =>
+  useMutation({
+    mutationFn: async (payload) => {
+      const response = await axiosInstance.post(PATH_API.SCORES(lectureId, examId), payload);
+      return response.data.data;
+    },
+  });

--- a/src/api/queryKeys.js
+++ b/src/api/queryKeys.js
@@ -16,6 +16,7 @@ export const QUERY_KEY = {
   // examination (test)
   EXAM_CATEGORY: (academyId) => PATH_API.EXAM_CATEGORY(academyId),
   GETEXAMLIST: (lectureId) => PATH_API.GETEXAMLIST(lectureId),
+  SCORELIST: (lectureId, academyId) => PATH_API.SCORES(lectureId, academyId),
 
   // manage lectures
   LECTURELIST: PATH_API.LECTURELIST,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #75 

## 📝작업 내용

성적 입력, 조회, 수정 api 연동 작업이 완료되었습니다.
성적 조회시 성적이 입력이 되어 있지 않은 학생은 기본적으로 0으로 표기하고
수정 버튼을 눌러 성적을 입력시 성적 입력 api로 호출할 수 있도록 하였고
기존 성적이 있는 학생들은 수정버튼을 눌러 성적을 변경시 성적 수정 api 호출할 수 있도록 작업하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
