### PR TITLE
#83 check password

### DIFF
--- a/src/api/path.js
+++ b/src/api/path.js
@@ -13,6 +13,7 @@ export const PATH_API = {
   REISSUE_TOKEN: '/user/refresh-token',
   PROFILE_BASIC: (userId) => `/user/${userId}/basic-info`,
   CANCEL_ACCOUNT: (userId) => `/user/${userId}`,
+  CHECK_PW: '/user/check-password',
   // register
   REGISTER_ACADEMY: '/registeration/request/academy',
   REGISTER_TEACHER: '/registeration/request/user',

--- a/src/api/queries/user/useCheckPw.js
+++ b/src/api/queries/user/useCheckPw.js
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+import { axiosInstance } from '../../axios';
+import { PATH_API } from '../../path';
+
+export const useCheckPassword = () =>
+  useMutation({
+    mutationFn: async (payload) => {
+      const response = await axiosInstance.post(PATH_API.CHECK_PW, payload);
+      return response.data;
+    },
+  });

--- a/src/pages/director/profile/updateProfile.jsx
+++ b/src/pages/director/profile/updateProfile.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Box, Button, Container, TextField, Typography, Grid, Avatar, Snackbar, IconButton } from '@mui/material';
+import { Box, Button, Container, TextField, Typography, Grid, Avatar, Snackbar, IconButton, Alert } from '@mui/material';
 import { Close } from '@mui/icons-material';
 import dayjs from 'dayjs';
 import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
@@ -12,6 +12,7 @@ import { SimpleDialog, SubmitButtons } from '../../../components';
 import { useUpdateProfile } from '../../../api/queries/user/useProfile';
 import { useUserAuthStore } from '../../../store';
 import { useCancelAccount } from '../../../api/queries/user/useCancelAccount';
+import { useCheckPassword } from '../../../api/queries/user/useCheckPw';
 
 const directorProfile = {
   personal: {
@@ -30,17 +31,28 @@ const directorProfile = {
 
 export default function UpdateProfile() {
   const [passed, setPassed] = useState(false);
+  const ckpassword = useCheckPassword();
 
-  return <Container sx={{ width: 400, p: 5 }}>{passed ? <UpdateProfileForm currentInfo={directorProfile} /> : <CheckPasswd setPassed={setPassed} />}</Container>;
+  return <Container sx={{ width: 400, p: 5 }}>{passed ? <UpdateProfileForm currentInfo={directorProfile} /> : <CheckPasswd setPassed={setPassed} ckpassword={ckpassword} />}</Container>;
 }
 
-function CheckPasswd({ setPassed }) {
+function CheckPasswd({ setPassed, ckpassword }) {
+  const [hasfailed, setfailed] = useState(false);
+
   const handleSubmit = (e) => {
     e.preventDefault();
-    const password = e.target.password.value;
-
-    // TODO: if 올바르지 않은 비밀번호일 때 처리
-    setPassed(true);
+    const password1 = e.target.password.value;
+    ckpassword.mutate(
+      {
+        password: password1,
+      },
+      {
+        onSuccess: (data) => {
+          if (data.isMatched) setPassed(true);
+          else setfailed(true);
+        },
+      }
+    );
   };
 
   return (
@@ -48,7 +60,8 @@ function CheckPasswd({ setPassed }) {
       <Typography variant="h6" sx={{ mb: 7 }}>
         비밀번호 확인
       </Typography>
-      <TextField name="password" label="비밀번호" required fullWidth sx={{ my: 1 }} />
+      <TextField name="password" label="비밀번호" required error={hasfailed} fullWidth type="password" sx={{ my: 1 }} />
+      {hasfailed ? <Alert severity="error">잘못된 비밀번호입니다.</Alert> : null}
       <Button type="submit" variant="contained" fullWidth sx={{ mt: 3 }}>
         확인
       </Button>

--- a/src/pages/teacher/profile/teacherUpdateProfile.jsx
+++ b/src/pages/teacher/profile/teacherUpdateProfile.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Avatar, Box, Button, Container, Grid, IconButton, Snackbar, TextField, Typography } from '@mui/material';
+import { Alert, Avatar, Box, Button, Container, Grid, IconButton, Snackbar, TextField, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import dayjs from 'dayjs';
 import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
@@ -12,21 +12,33 @@ import { useUserAuthStore } from '../../../store';
 import { SubmitButtons } from '../../../components';
 import { useUpdateProfile } from '../../../api/queries/user/useProfile';
 import { useCancelAccount } from '../../../api/queries/user/useCancelAccount';
+import { useCheckPassword } from '../../../api/queries/user/useCheckPw';
 
 export default function TeacherUpdateProfile() {
   const { user } = useUserAuthStore();
   const [passed, setPassed] = useState(false);
+  const ckpassword = useCheckPassword();
 
-  return <Container sx={{ width: 400, p: 5 }}>{passed ? <UpdateProfileForm currentInfo={user} /> : <CheckPasswd setPassed={setPassed} />}</Container>;
+  return <Container sx={{ width: 400, p: 5 }}>{passed ? <UpdateProfileForm currentInfo={user} /> : <CheckPasswd setPassed={setPassed} ckpassword={ckpassword} />}</Container>;
 }
 
-function CheckPasswd({ setPassed }) {
+function CheckPasswd({ setPassed, ckpassword }) {
+  const [hasfailed, setfailed] = useState(false);
+
   const handleSubmit = (e) => {
     e.preventDefault();
     const password1 = e.target.password1.value;
-
-    // TODO: if 올바르지 않은 비밀번호일 때 처리.
-    setPassed(true);
+    ckpassword.mutate(
+      {
+        password: password1,
+      },
+      {
+        onSuccess: (data) => {
+          if (data.isMatched) setPassed(true);
+          else setfailed(true);
+        },
+      }
+    );
   };
 
   return (
@@ -34,7 +46,8 @@ function CheckPasswd({ setPassed }) {
       <Typography variant="h6" sx={{ mb: 7 }}>
         비밀번호 확인
       </Typography>
-      <TextField name="password1" label="비밀번호" required fullWidth type="password" sx={{ my: 1 }} />
+      <TextField name="password1" label="비밀번호" required error={hasfailed} fullWidth type="password" sx={{ my: 1 }} />
+      {hasfailed ? <Alert severity="error">잘못된 비밀번호입니다.</Alert> : null}
       <Button type="submit" variant="contained" fullWidth sx={{ mt: 3 }}>
         확인
       </Button>


### PR DESCRIPTION
## #️⃣연관된 이슈

#83 

## 📝작업 내용

비밀번호 확인 api를 연동하여 원장페이지 및 강사페이지에서 프로필 수정시 비밀번호를 다시 한번 체크하도록 하였음.
잘못된 비밀번호 입력시 alert가 뜸.

### 스크린샷 (선택)
<img width="1664" alt="스크린샷 2024-11-26 오후 2 34 08" src="https://github.com/user-attachments/assets/f3e8ab87-3a38-4bce-aa57-546c2b056fe0">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
