### PR TITLE
#93 fix profile img

### DIFF
--- a/src/components/button/profileButton.jsx
+++ b/src/components/button/profileButton.jsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { IconButton, Avatar, Menu, MenuItem, Box, Typography, Divider, ListItemIcon } from '@mui/material';
+import { IconButton, Avatar, Menu, MenuItem, Box, Typography, Divider } from '@mui/material';
 import { AccountBoxRounded, LogoutRounded } from '@mui/icons-material';
 
 import useLogout from '../../api/queries/user/useLogout';
@@ -14,10 +14,15 @@ import { useProfileImage } from '../../api/queries/user/useProfile';
 export default function ProfileButton({ position }) {
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState(null);
-  const { user } = useUserAuthStore();
+  const { user, profileImg, updateProfileImg } = useUserAuthStore();
   const logoutMutation = useLogout();
 
   const { data: imageUrl } = useProfileImage(user.user_id);
+
+  useEffect(() => {
+    // user auth store에 이미지 url 저장
+    if (imageUrl) updateProfileImg(`${imageUrl}?timestamp=${new Date().getTime()}`);
+  }, [imageUrl, updateProfileImg]);
 
   const handleMouseOver = (event) => {
     setAnchorEl(event.currentTarget);
@@ -34,7 +39,7 @@ export default function ProfileButton({ position }) {
   return (
     <>
       <IconButton onMouseOver={handleMouseOver}>
-        <Avatar src={imageUrl} />
+        <Avatar src={profileImg} />
       </IconButton>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
         <Box sx={{ paddingX: 2 }}>

--- a/src/pages/director/profile/directorProfile.jsx
+++ b/src/pages/director/profile/directorProfile.jsx
@@ -8,7 +8,6 @@ import { Edit } from '@mui/icons-material';
 import { useUserAuthStore } from '../../../store';
 import { CustomLink } from '../../../components';
 import { PATH } from '../../../route/path';
-import { useProfileImage } from '../../../api/queries/user/useProfile';
 import { useAcademyInfo } from '../../../api/queries/user/useAcademyInfo';
 
 // const user = {
@@ -32,10 +31,9 @@ import { useAcademyInfo } from '../../../api/queries/user/useAcademyInfo';
 
 export default function DirectorProfile() {
   const navigate = useNavigate();
-  const { user } = useUserAuthStore(); // 기본 정보
+  const { user, profileImg } = useUserAuthStore(); // 기본 정보
 
   const { data: academyInfo } = useAcademyInfo(); // 학원 정보
-  const { data: imageUrl } = useProfileImage(user.user_id);
 
   const handleClickUpdate = () => {
     navigate('/director/profile/update');
@@ -45,7 +43,7 @@ export default function DirectorProfile() {
     <Container sx={{ width: '50vw', padding: 5 }}>
       <Grid container spacing={5}>
         <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'center' }}>
-          <Avatar src={imageUrl} sx={{ width: 100, height: 100 }} />
+          <Avatar src={profileImg} sx={{ width: 100, height: 100 }} />
         </Grid>
         <Grid item xs={8} sx={{ display: 'flex', alignItems: 'center' }}>
           <Typography variant="h6">{user.user_name} 원장</Typography>

--- a/src/pages/director/profile/updateProfile.jsx
+++ b/src/pages/director/profile/updateProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Box, Button, Container, TextField, Typography, Grid, Avatar, Snackbar, IconButton, Alert, Badge } from '@mui/material';
@@ -12,7 +12,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 import { SimpleDialog, SubmitButtons } from '../../../components';
-import { useProfileImage, useUpdateProfile, useUpdateProfileImage } from '../../../api/queries/user/useProfile';
+import { useUpdateProfile, useUpdateProfileImage } from '../../../api/queries/user/useProfile';
 import { useAcademyInfo, useUpdateAcademyInfo } from '../../../api/queries/user/useAcademyInfo';
 import { useUserAuthStore } from '../../../store';
 import { useCancelAccount } from '../../../api/queries/user/useCancelAccount';
@@ -64,23 +64,17 @@ function CheckPasswd({ setPassed, ckpassword }) {
 
 function UpdateProfileForm() {
   const navigate = useNavigate();
-  const { user } = useUserAuthStore();
+  const { user, profileImg, updateProfileImg } = useUserAuthStore();
   const [date, setDate] = useState(dayjs(user.birth_date));
   const [openDialog, setOpenDialog] = useState(false);
   const [openSnackbar, setOpenSnackbar] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
-  const [imgUrl, setImgUrl] = useState(''); // Avatar 띄우기 용
 
-  const { data: profileImg } = useProfileImage(user.user_id);
   const { data: academyInfo, refetch: refetchAcademyInfo } = useAcademyInfo();
   const updateProfileMutation = useUpdateProfile(user.user_id);
   const updateAcademyMutation = useUpdateAcademyInfo();
   const updateProfileImgMutation = useUpdateProfileImage(user.user_id);
   const cancelAccountMutation = useCancelAccount(user.user_id);
-
-  useEffect(() => {
-    if (profileImg) setImgUrl(profileImg);
-  }, [profileImg]);
 
   const handleOpenDialog = () => {
     setOpenDialog(true);
@@ -106,14 +100,9 @@ function UpdateProfileForm() {
     const submitData = new FormData();
     submitData.append('file', file);
     updateProfileImgMutation.mutate(submitData, {
-      onSuccess: () => {
+      onSuccess: (data) => {
         alert('프로필 이미지 수정 성공!');
-
-        const reader = new FileReader();
-        reader.readAsDataURL(file);
-        reader.onloadend = () => {
-          setImgUrl(reader.result);
-        };
+        updateProfileImg(`${data.image}?timestamp=${new Date().getTime()}`);
       },
       onError: () => {
         alert('프로필 이미지 수정 실패!');
@@ -180,7 +169,7 @@ function UpdateProfileForm() {
         <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'center' }}>
           <Button component="label" role={undefined} tabIndex={-1} disableRipple>
             <Badge anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }} badgeContent={<EditOutlined />} tabIndex={-1}>
-              <Avatar src={imgUrl} sx={{ width: 100, height: 100 }} />
+              <Avatar src={profileImg} sx={{ width: 100, height: 100 }} />
             </Badge>
             <VisuallyHiddenInput type="file" accept="image/*" onChange={handleChangeImage} />
           </Button>

--- a/src/pages/teacher/profile/teacherProfile.jsx
+++ b/src/pages/teacher/profile/teacherProfile.jsx
@@ -1,30 +1,22 @@
 import { Avatar, Box, Container, Grid, IconButton, Typography } from '@mui/material';
 import { Edit } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import dayjs from 'dayjs';
 import { useUserAuthStore } from '../../../store';
 import { CustomLink, TitleMedium } from '../../../components';
 import { PATH } from '../../../route/path';
-import { useProfileImage } from '../../../api/queries/user/useProfile';
 
 export default function TeacherProfile() {
-  const { user, lectures } = useUserAuthStore();
+  const { user, profileImg, lectures } = useUserAuthStore();
   const navigate = useNavigate();
-  const [imgUrl, setImgUrl] = useState('');
-
-  const { data: profileImg } = useProfileImage(user.user_id);
-
-  useEffect(() => {
-    if (profileImg) setImgUrl(profileImg);
-  }, [profileImg]);
 
   return (
     <Container sx={{ width: '50vw', padding: 5 }}>
       <TitleMedium title="My Profile" />
       <Grid container spacing={5}>
         <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'center' }}>
-          <Avatar src={imgUrl} sx={{ width: 100, height: 100 }} />
+          <Avatar src={profileImg} sx={{ width: 100, height: 100 }} />
         </Grid>
         <Grid item xs={8} sx={{ display: 'flex', alignItems: 'center' }}>
           <Typography variant="h6">{user?.user_name}</Typography>

--- a/src/pages/teacher/profile/teacherUpdateProfile.jsx
+++ b/src/pages/teacher/profile/teacherUpdateProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { Alert, Avatar, Badge, Box, Button, Container, Grid, IconButton, Snackbar, TextField, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
@@ -11,7 +11,7 @@ import styled from '@emotion/styled';
 
 import { useUserAuthStore } from '../../../store';
 import { SubmitButtons } from '../../../components';
-import { useProfileImage, useUpdateProfile, useUpdateProfileImage } from '../../../api/queries/user/useProfile';
+import { useUpdateProfile, useUpdateProfileImage } from '../../../api/queries/user/useProfile';
 import { useCancelAccount } from '../../../api/queries/user/useCancelAccount';
 import { useCheckPassword } from '../../../api/queries/user/useCheckPw';
 
@@ -62,21 +62,15 @@ function CheckPasswd({ setPassed, ckpassword }) {
 
 function UpdateProfileForm({ currentInfo }) {
   const navigate = useNavigate();
-  const { user } = useUserAuthStore();
+  const { user, profileImg, updateProfileImg } = useUserAuthStore();
   const [date, setDate] = useState(dayjs(currentInfo.birth_date));
   const [openDialog, setOpenDialog] = useState(false);
   const [openSnackbar, setOpenSnackbar] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
-  const [imgUrl, setImgUrl] = useState('');
 
-  const { data: profileImg } = useProfileImage(user.user_id);
   const updateProfileMutation = useUpdateProfile(user.user_id);
   const updateProfileImgMutation = useUpdateProfileImage(user.user_id);
   const deleteAccountMutation = useCancelAccount(user.user_id);
-
-  useEffect(() => {
-    if (profileImg) setImgUrl(profileImg);
-  }, [profileImg]);
 
   const handleOpenDialog = () => {
     setOpenDialog(true);
@@ -113,14 +107,9 @@ function UpdateProfileForm({ currentInfo }) {
     const submitData = new FormData();
     submitData.append('file', file);
     updateProfileImgMutation.mutate(submitData, {
-      onSuccess: () => {
+      onSuccess: (data) => {
         alert('프로필 이미지 수정 성공!');
-
-        const reader = new FileReader();
-        reader.readAsDataURL(file);
-        reader.onloadend = () => {
-          setImgUrl(reader.result);
-        };
+        updateProfileImg(`${data.image}?timestamp=${new Date().getTime()}`);
       },
       onError: () => {
         alert('프로필 이미지 수정 실패');
@@ -151,7 +140,7 @@ function UpdateProfileForm({ currentInfo }) {
         <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'center' }}>
           <Button component="label" role={undefined} tabIndex={-1} disableRipple>
             <Badge anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }} badgeContent={<EditOutlined />} tabIndex={-1}>
-              <Avatar src={imgUrl} sx={{ width: 100, height: 100 }} />
+              <Avatar src={profileImg} sx={{ width: 100, height: 100 }} />
             </Badge>
             <VisuallyHiddenInput type="file" accept="image/*" onChange={handleChangeImage} />
           </Button>

--- a/src/store/user/userAuthStore.js
+++ b/src/store/user/userAuthStore.js
@@ -17,15 +17,17 @@ const UserAuthStore = (set) => ({
   // State
   isLoggedIn: false,
   user: null,
+  profileImg: '',
   lectures: [],
 
   // Actions
   login: (userData) => set({ isLoggedIn: true, user: userData }),
-  logout: () => set({ isLoggedIn: false, user: null, lectures: [] }),
+  logout: () => set({ isLoggedIn: false, user: null, profileImg: '', lectures: [] }),
   updateUser: (userData) =>
     set((state) => ({
       user: { ...state.user, ...userData },
     })),
+  updateProfileImg: (imgUrl) => set({ profileImg: imgUrl }),
   lecture: (lecture) => set({ lectures: lecture }),
 });
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #93 

## 📝작업 내용

> 프로필이미지 변경 시 브라우저의 캐싱으로 인해 계속 이전 프로필이미지가 보이는 이슈를 서버에서 받은 url에 timestamp 쿼리를 추가하여 해결하였습니다. 
또한, 이미지 변경할 때를 제외하고는 url이 변경될 일이 없으므로 userAuthStore에서 전역으로 관리하도록 했습니다.
강사 페이지에도 적용했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
