### PR TITLE
#97 fix signup

### DIFF
--- a/src/pages/director/directorHome.jsx
+++ b/src/pages/director/directorHome.jsx
@@ -107,11 +107,11 @@ export default function DirectorHome() {
         <TitleMedium title="최근 등록요청" />
         <Grid container spacing={1}>
           <Grid item xs={6}>
-            <Typography sx={{ mb: 2, fontWeight: 'bold' }}>강사 (담당강의)</Typography>
+            <Typography sx={{ mb: 2, fontWeight: 'bold' }}>강사</Typography>
             {teacherReqList &&
               teacherReqList.slice(0, 3).map((teacher) => {
                 const teacherInfo = teacher.user;
-                return <Typography key={teacherInfo.user_id}>{`${teacherInfo.user_name} (${teacherInfo.lectures.join(', ')})`}</Typography>;
+                return <Typography key={teacherInfo.user_id}>{`${teacherInfo.user_name} 강사`}</Typography>;
               })}
           </Grid>
           <Divider orientation="vertical" variant="middle" flexItem />

--- a/src/pages/director/manageMembers/requestList.jsx
+++ b/src/pages/director/manageMembers/requestList.jsx
@@ -178,7 +178,7 @@ export default function RequestList() {
                       <ListItemIcon>
                         <Checkbox checked={checkedTeachers.indexOf(teacher) !== -1} />
                       </ListItemIcon>
-                      <ListItemText primary={teacherInfo.user_name} />
+                      <ListItemText primary={`${teacherInfo.user_name} 강사`} />
                     </ListItemButton>
                   );
                 })

--- a/src/pages/register/register.jsx
+++ b/src/pages/register/register.jsx
@@ -33,7 +33,7 @@ export default function Register({ position }) {
         {status === 0 && <BeforeRegister position={position} handleClick={handleClick} />}
         {status === 1 && <RegisterAcademy setStatus={setStatus} />}
         {status === 2 && <RegisterTeacher setStatus={setStatus} />}
-        {status === 3 && <AfterRegister />}
+        {status === 3 && <AfterRegister position={position} />}
       </Box>
     </Container>
   );
@@ -176,7 +176,7 @@ function RegisterTeacher({ setStatus }) {
   );
 }
 
-function AfterRegister() {
+function AfterRegister({ position }) {
   return (
     <Grid container spacing={3} sx={{ mt: 3 }}>
       <Grid item xs={12}>
@@ -187,7 +187,7 @@ function AfterRegister() {
       <Grid item xs={12}>
         <Typography variant="body1" align="center">
           등록 요청이 완료되었습니다. <br />
-          승인될 때까지 대기해주세요.
+          {position === 'director' ? '관리자 심사 후 승인 여부를 이메일로 전송해드립니다. 승인 후 재로그인해주세요.' : '승인 후 재로그인해주세요.'}
         </Typography>
       </Grid>
     </Grid>

--- a/src/pages/signup/signup.jsx
+++ b/src/pages/signup/signup.jsx
@@ -124,7 +124,7 @@ function SignupForm({ position, setStatus, setName }) {
           console.log(res.message);
         },
         onError: (error) => {
-          if (error.errorCode === 409) alert('이미 등록된 이메일입니다. \n다른 이메일로 다시 시도해주세요.');
+          if (error.errorCode === 409) alert('이미 등록된 이메일(전화번호)입니다. \n다른 이메일(전화번호)로 다시 시도해주세요.');
           else alert('서버 오류로 회원가입에 실패하였습니다. \n나중에 다시 시도해주세요.');
           console.log(error.message);
         },


### PR DESCRIPTION
## #️⃣연관된 이슈

> #97 회원가입 실패 메시지 오류

## 📝작업 내용

> 이메일 혹은 전화번호 중복으로 회원가입 실패 시 경고문 이메일 중복이라고만 뜨는 것 수정.
추가로 학원/강사 등록요청 성공 시 문구 변경. (원장은 학원 등록요청 보낸 후 관리자가 승인 여부를 이메일로 알려주면 재로그인하면 됨, 강사는 원장이 승인했다고 하면? 재로그인하면 됨)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
