### PR TITLE
fix: split()함수가 없어 발생하는 오류 해결 #117

### DIFF
--- a/src/pages/teacher/teacherHome.jsx
+++ b/src/pages/teacher/teacherHome.jsx
@@ -34,8 +34,8 @@ export default function TeacherHome() {
                 Today&apos;s Lectures
               </Typography>
               {lectures.map((lecture) => {
-                const time1 = lecture.start_time.split('T')[1].split('.')[0].split(':');
-                const time2 = lecture.end_time.split('T')[1].split('.')[0].split(':');
+                const time1 = lecture.start_time;
+                const time2 = lecture.end_time;
                 const week = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY'];
                 const today = week[new Date().getDay()];
                 if (lecture.days.includes(today))
@@ -47,7 +47,7 @@ export default function TeacherHome() {
                           <Typography sx={{ ml: '15px', fontFamily: 'Inter' }}>{lecture.lecture_name}</Typography>
                         </Box>
                         <Typography sx={{ fontFamily: 'Inter' }}>
-                          {time1[0]}:{time1[1]}~{time2[0]}:{time2[1]}
+                          {time1}~{time2}
                         </Typography>
                         <Typography sx={{ fontFamily: 'Inter' }}>수강생 {lecture.headcount}명</Typography>
                       </Grid>


### PR DESCRIPTION
## #️⃣연관된 이슈

#117 

## 📝작업 내용

서버에서 응답하는 강의의 시작시간형식이 변경됨에 따라 오류 발생이 안되도록 코드 수정
기존 : YYYY-MM-DDTHH:mm:ss 
현재 : HH:mm
split함수 제거. 서버로 부터 받은 정보 그대로 출력

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
