### PR TITLE
fix: 1 페이지일 때만 lastNoticeId 업데이트 #122

### DIFF
--- a/src/pages/director/notice/directorNotice.jsx
+++ b/src/pages/director/notice/directorNotice.jsx
@@ -36,11 +36,11 @@ export default function DirectorNotice() {
   const deleteNoticeMutation = useNoticeDelete();
 
   useEffect(() => {
-    if (notices) {
+    if (notices && page === 1) {
       // 공지가 없으면 academyId&0&0으로
       setLastNoticeId(notices.notice_count !== 0 ? notices.notice_list[0].notice_id : `${user.academy_id}&0&0`);
     }
-  }, [notices, user]);
+  }, [notices, user, page]);
 
   const handleChangePage = (e, value) => {
     setPage(value);

--- a/src/pages/teacher/notice/courseNotice.jsx
+++ b/src/pages/teacher/notice/courseNotice.jsx
@@ -33,12 +33,12 @@ export default function CourseNotice() {
   const [lastNoticeId, setLastNoticeId] = useState('');
 
   useEffect(() => {
-    if (notices) {
+    if (notices && pageNo === 1) {
       // 공지를 불러왔을 때 마지막 noticeId.
       // 공지가 없다면 user.academy_id&courseId&0 으로 세팅.
       setLastNoticeId(notices.notice_count !== 0 ? notices.notice_list[0].notice_id : `${user.academy_id}&${courseID}&0`);
     }
-  }, [notices, courseID, user]);
+  }, [notices, courseID, user, pageNo]);
 
   const handleClickAdd = () => {
     navigate(`/teacher/class/${params.courseid}/notice/add`, { state: { noticeId: lastNoticeId } });


### PR DESCRIPTION
## #️⃣연관된 이슈

> #122

## 📝작업 내용

> 1 페이지 아닌 곳에서 공지 생성 시 실패 해결.
1 페이지가 아닐 때는 lastNoticeId 업데이트 X.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
